### PR TITLE
Add support for shared memory.

### DIFF
--- a/transit/include/flags_tr.h
+++ b/transit/include/flags_tr.h
@@ -134,4 +134,10 @@
 #define TERR_ALLOC        0x000040
 #define TERR_DBG          0x000080
 
+/* Shared memory flags: */
+#define TSHM_START        0x000000 /* Default state     */
+#define TSHM_INIT         0x000001 /* Space initialized */
+#define TSHM_WRITTEN      0x000002 /* Space written     */
+#define TSHM_ERROR        0x000004 /* Error             */
+
 #endif /* _FLAGS_TR_H */

--- a/transit/include/opacity.h
+++ b/transit/include/opacity.h
@@ -6,9 +6,12 @@
 
 /* src/opacity.c */
 extern int opacity P_((struct transit *tr));
-extern int readopacity P_((struct transit *tr, FILE *fp));
 extern int calcprofiles P_((struct transit *tr));
 extern int calcopacity P_((struct transit *tr, FILE *fp));
+extern int readopacity P_((struct transit *tr, FILE *fp));
+extern int shareopacity P_((struct transit *tr, FILE *fp));
+extern int attachopacity P_((struct transit *tr));
+extern int mountopacity P_((struct transit *tr));
 extern int freemem_opacity P_((struct opacity *op, long *pi));
 
 #undef P_

--- a/transit/include/structures_tr.h
+++ b/transit/include/structures_tr.h
@@ -171,6 +171,14 @@ struct extinction{
 };
 
 
+struct opacityhint{
+  int master_PID;       /* Process that will write the shared memory        */
+  int num_attached;     /* Count of processes attached to the main segment  */
+  unsigned int status;  /* Flags concerning the state of the shared memory  */
+  long Nwave, Ntemp, Nlayer, Nmol; /* Info necessary for sizing shared mem  */
+};
+
+
 struct opacity{
   PREC_RES ****o;         /* Opacity grid [temp][iso][rad][wav]             */
   PREC_VOIGT ***profile;  /* Voigt profiles [nDop][nLor][2*profsize+1]      */
@@ -184,6 +192,10 @@ struct opacity{
   int *molID;             /* Opacity-grid molecule ID array                 */
   long Nwave, Ntemp, Nlayer, Nmol, /* Number of elements in opacity grid    */
       nDop, nLor;         /* Number of Doppler and Lorentz-width samples    */
+  int hintID;             /* Shared memory ID of the hint segment           */
+  struct opacityhint *hint; /* Information about the shared memory          */
+  int mainID;             /* Shared memory ID of the main segment           */
+  void *mainaddr;         /* Shared memory address of the main segment      */
 };
 
 
@@ -341,6 +353,7 @@ struct transithint{
   _Bool mass;           /* Whether the abundances read by getatm are by
                            mass or number                                    */
   _Bool opabreak;       /* Break after opacity calculation flag              */
+  _Bool opashare;       /* Attempt to place opacity grid in shared memory.   */
   long fl;              /* flags                                             */
   _Bool userefraction;  /* Whether to use variable refraction                */
   _Bool savefiles    ;  /* Whether to save files                             */
@@ -387,6 +400,7 @@ struct transit{
       wavs, wns, temp; /* wavelength, wavenumber, and temperature           */
   prop_atm atm;      /* Sampled atmospheric data                            */
   _Bool opabreak;    /* Break after opacity calculation                     */
+  _Bool opashare;    /* Attempt to place opacity grid in shared memory.     */
   int ndivs,         /* Number of exact divisors of the oversampling factor */
      *odivs;         /* Exact divisors of the oversampling factor           */
   int voigtfine;     /* Number of fine-bins of the Voigt function           */

--- a/transit/include/structures_tr.h
+++ b/transit/include/structures_tr.h
@@ -174,7 +174,7 @@ struct extinction{
 struct opacityhint{
   int master_PID;       /* Process that will write the shared memory        */
   int num_attached;     /* Count of processes attached to the main segment  */
-  unsigned int status;  /* Flags concerning the state of the shared memory  */
+  volatile long status; /* Flags concerning the state of the shared memory  */
   long Nwave, Ntemp, Nlayer, Nmol; /* Info necessary for sizing shared mem  */
 };
 

--- a/transit/include/transit.h
+++ b/transit/include/transit.h
@@ -27,9 +27,11 @@
 #include <stdarg.h>
 #include <math.h>
 #include <errno.h>
-#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <unistd.h>
 #include <sampling.h>
 #include <profile.h>

--- a/transit/include/transit.h
+++ b/transit/include/transit.h
@@ -21,6 +21,9 @@
 /* Revision        March 19th,   2014 Jasmina Blecic
                    added eclipse ray solution                      */
 
+/* Required for compilation with shared memory libraries.                   */
+#define _XOPEN_SOURCE 700
+
 #ifndef _TRANSIT_H
 #define _TRANSIT_H
 

--- a/transit/src/argum.c
+++ b/transit/src/argum.c
@@ -144,6 +144,7 @@ processparameters(int argc,            /* Number of command-line args  */
     CLA_RRADIUS,
     CLA_GSURF,
     CLA_OPABREAK,
+    CLA_OPASHARE,
     CLA_NDOP,
     CLA_NLOR,
     CLA_DMIN,
@@ -322,6 +323,8 @@ processparameters(int argc,            /* Number of command-line args  */
      "Temperature sample spacing (in kelvin)."},
     {"justOpacity",      CLA_OPABREAK,  no_argument, NULL, NULL,
      "If set, End execution after the opacity-grid calculation."},
+    {"shareOpacity",      CLA_OPASHARE,  no_argument, NULL, NULL,
+     "If set, attempt to place the opacity grid into shared memory."},
 
     /* Resulting ray options:                 */
     {NULL,        0,            HELPTITLE,         NULL, NULL,
@@ -530,6 +533,9 @@ processparameters(int argc,            /* Number of command-line args  */
       break;
     case CLA_OPABREAK: /* Bool: End after opacity calculation               */
       hints->opabreak = 1;
+      break;
+    case CLA_OPASHARE: /* Bool: Place opacity grid in shared memory         */
+      hints->opashare = 1;
       break;
 
     /* Radius parameters:                                                   */
@@ -794,6 +800,9 @@ acceptgenhints(struct transit *tr){
 
   /* Pass flag to break after the opacity-grid calculation:                 */
   tr->opabreak = th->opabreak;
+
+  /* Pass flag to place opacity grid in shared memory:                      */
+  tr->opashare = th->opashare;
 
   /* Set interpolation function flag:                                       */
   switch(tr->fl & TRU_SAMPBITS){

--- a/transit/src/argum.c
+++ b/transit/src/argum.c
@@ -56,6 +56,9 @@ Thank you for using transit!
 /* Revision        April 26th,   2014 Jasmina Blecic
                    added new function for ray grid                         */
 
+/* Required for compilation with shared memory libraries.                   */
+#define _XOPEN_SOURCE 700
+
 #include <time.h>
 #include <transit.h>
 #include <version_tr.h>

--- a/transit/src/opacity.c
+++ b/transit/src/opacity.c
@@ -206,15 +206,13 @@ opacity(struct transit *tr){
          processes have detached.                                           */
       struct shmid_ds buf1, buf2;
       shmctl(op.hintID, IPC_STAT, &buf1);
-      transitprint(1, verblevel, "STATING ALL OF THE THINGS.\n");
 
       do {
         shmctl(op.mainID, IPC_STAT, &buf2);
       }
       while (buf2.shm_nattch != buf1.shm_nattch);
 
-      transitprint(1, verblevel, "REMOVING ALL OF THE THINGS. 1: %d, 2: %d\n",
-        buf1.shm_nattch, buf2.shm_nattch);
+      transitprint(1, verblevel, "Marking shared memory for removal.\n");
       shmctl(op.hintID, IPC_RMID, &buf1);
       shmctl(op.mainID, IPC_RMID, &buf2);
 
@@ -582,7 +580,7 @@ shareopacity(struct transit *tr, /* transit struct                          */
     return 1;
 
   /* Read arrays:                                                           */
-  void *p = op->mainaddr;
+  char *p = op->mainaddr;
   fread(p, sizeof(int),      op->Nmol,   fp);
   p += sizeof(int) * op->Nmol;
   fread(p,  sizeof(PREC_RES), op->Ntemp,  fp);
@@ -652,14 +650,14 @@ mountopacity(struct transit *tr){ /* transit struct                         */
   struct opacity *op=tr->ds.op;   /* opacity struct                         */
   int i, t, r;  /* for-loop indices                                         */
 
-  void *p = op->mainaddr;
-  op->molID = p;
+  char *p = op->mainaddr;
+  op->molID = (int *) p;
   p += sizeof(int) * op->Nmol;
-  op->temp = p;
+  op->temp = (PREC_RES *) p;
   p += sizeof(PREC_RES) * op->Ntemp;
-  op->press = p;
+  op->press = (PREC_RES *) p;
   p += sizeof(PREC_RES) * op->Nlayer;
-  op->wns = p;
+  op->wns = (PREC_RES *) p;
   p += sizeof(PREC_RES) * op->Nwave;
 
   op->o      = (PREC_RES ****)       calloc(op->Nlayer, sizeof(PREC_RES ***));

--- a/transit/src/transitstd.c
+++ b/transit/src/transitstd.c
@@ -182,27 +182,35 @@ int
 fileexistopen(char *in,    /* Input filename                                */
               FILE **fp){  /* Opened file pointer if successful             */
   struct stat st;
+
+  /* Return if no file was given:                                           */
+  if (!in)
+    return 0;
+
+  /* Check if the suggested file exists. If it doesn't, use defaults:       */
+  if (stat(in, &st) == -1){
+    if (errno == ENOENT)
+      return -1;
+    else
+      return -4;
+  }
+
+  /* Check if suggested file is of a valid type:                            */
+  if (!(S_ISREG(st.st_mode) || S_ISFIFO(st.st_mode)))
+    return -2;
+
+  /* If no file pointer variable is given, we've done all we can:           */
+  if (fp == NULL)
+    return 1;
+
+  /* If a file pointer is given, attempt to open the file:                  */
   *fp = NULL;
 
-  if(in){
-    /* Check if the suggested file exists. If it doesn't, use defaults:     */
-    if (stat(in, &st) == -1){
-      if(errno == ENOENT)
-        return -1;
-      else
-        return -4;
-    }
-    /* Not of the valid type:                                               */
-    else if(!(S_ISREG(st.st_mode) || S_ISFIFO(st.st_mode)))
-      return -2;
-    /* Not openable:                                                        */
-    else if(((*fp)=fopen(in,"r")) == NULL)
-      return -3;
-    /* No problem!:                                                         */
-    return 1;
-  }
-  /* No file was requested:                                                 */
-  return 0;
+  if (((*fp)=fopen(in,"r")) == NULL)
+    return -3;
+
+  /* Success:                                                               */
+  return 1;
 }
 
 


### PR DESCRIPTION
Please test for output. To test, you'll need to pass transit chains the `--shareOpacity` flag from BART. Using shared memory is **not** currently the default behavior.

Let me know if you're ready to merge, and I will rebase it if necessary.
