### PR TITLE
Create a unified Makefile for the entire Transit package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Makefile - created for transit.
+#
+# This Makefile calls subsidiary Makefiles located in the various modules that
+# make up Transit. Those Makefiles should be maintained as each module evolves.
+#
+# Revision    July 6, 2015    AJ Foster
+#             Created; naively calls module make commands.
+
+
+# Get the location of this Makefile.
+mkfile_dir := $(dir $(lastword $(MAKEFILE_LIST)))
+
+# `make [clean]` should run `make [clean]` on all of the modules.
+all: make_pu make_transit make_ctips
+clean: clean_pu clean_transit clean_ctips
+
+# The following builds the various modules using their respective `make`
+# tasks.
+#
+
+make_pu:
+	@echo "\nCompiling module pu..."
+	@cd $(mkfile_dir)/pu/ && make
+	@echo "Finished compiling pu."
+
+make_transit: make_pu
+	@echo "\nCompiling module transit..."
+	@cd $(mkfile_dir)/transit/ && make
+	@echo "Finished compiling transit."
+
+make_ctips:
+	@echo "\nCompiling CTIPS for pylineread..."
+	@cd $(mkfile_dir)/pylineread/src/ctips/ && make
+	@echo "Finished compiling CTIPS."
+
+
+# The following tasks clean the various modules using their respective
+# `make clean` commands.
+#
+
+clean_pu:
+	@echo "\nCleaning module pu..."
+	@cd $(mkfile_dir)/pu/ && make clean
+	@echo "Finished cleaning pu."
+
+clean_transit:
+	@echo "\nCleaning module transit..."
+	@cd $(mkfile_dir)/transit/ && make clean
+	@echo "Finished cleaning transit."
+
+clean_ctips:
+	@echo "\nCleaning CTIPS for pylineread..."
+	@cd $(mkfile_dir)/pylineread/src/ctips/ && make clean
+	@echo "Finished cleaning CTIPS."

--- a/README.md
+++ b/README.md
@@ -40,17 +40,13 @@ Clone the repository to your working directory:
 git clone --recursive https://github.com/exosports/transit transit/
 ```
 
-Compile the pu and transit programs (in that order), as well as the pylineread TIPS code:  
+Compile the pu and transit programs, as well as the pylineread TIPS code:  
 ```shell
-cd $topdir/transit/pu/  
-make  
-cd $topdir/transit/transit/  
-make  
-cd $topdir/transit/pylineread/src/ctips/
-make  
+cd $topdir/transit/
+make
 ```
 
-To remove the program binaries, execute (from the respective directories):  
+To remove the program binaries, execute:  
 ```shell
 make clean
 ```

--- a/doc/transit_user_manual/transit_user_manual.tex
+++ b/doc/transit_user_manual/transit_user_manual.tex
@@ -259,19 +259,12 @@ place the code: \newline
 \noindent Clone the repository to your working directory: \newline
 {\tttb git clone https://github.com/exosports/transit transit} \\
 
-\noindent Compile the {\tttm pu} and {\tttm transit} code (in this
-order): \newline
-{\tttb cd transit/pu} \\
-{\tttb make} \\
-{\tttb cd ../transit} \\
+\noindent Compile the {\tttm pu} and {\tttm transit} code, as well as
+the {\tttm pylineread} TIPS code: \newline
+{\tttb cd transit} \\
 {\tttb make} \\
 
-\noindent Compile the {\tttm pylineread} TIPS code: \\
-{\tttb cd ../pylineread/src/ctips} \\
-{\tttb make} \\
-
-\noindent To remove the program binaries, execute (from the respective
-directories): \newline
+\noindent To remove the program binaries, execute: \newline
 {\tttb make clean} \\
 
 \noindent Note that there will be warnings.


### PR DESCRIPTION
The makefile naively forwards the "make" and "make clean" commands to the various modules.
