### PR TITLE
Re-factored CIA code into a general Cross-section code

### DIFF
--- a/doc/transit_user_manual/transit_user_manual.tex
+++ b/doc/transit_user_manual/transit_user_manual.tex
@@ -353,7 +353,7 @@ strength, and isotpe index; and a tabulated list of partition-function
 values as a function of temperature.
 
 The inputs for transit are (1) an atmospheric file, (2) a TLI file
-(output from pylineread), (3) a collision-induced-absorption (CIA),
+(output from pylineread), (3) one or more cross-section (CS) file,
 (4) a molecular information file, and optionally (5) an opacity file.
 See section \ref{sec:input-transit} for further details on the transit
 input files and their required formats.
@@ -361,8 +361,8 @@ input files and their required formats.
 The atmospheric file defines the atmospheric model, indicating the
 species present, and their physical properties (radius, pressure,
 temperature, and species mole mixing ratio) given in a layer-by-layer
-style.  The input TLI file is the output from pylineread.  The CIA
-file is a tabulated list of CIA opacities as function of wavenumber
+style.  The input TLI file is the output from pylineread.  The CS
+file is a tabulated list of opacities as function of wavenumber
 and temperature.  The molecular information file contains additional
 species properties, is not expected to change (mass and collision
 diameter).  This file is provided by the Transit module.  The optional
@@ -610,7 +610,7 @@ command-line arguments.  Alternatively, the command-line arguments can
 be specified using a configuration file.  Before running {\transit},
 the user needs to obtain three types of input files, an atmospheric
 file, transit-line information (TLI) files (created by {\pylineread}),
-and collision-induced absorption (CIA) files.  Additionally,
+and cross-section (CS) files (e.g., for collision-induced absorption).  Additionally,
 {\transit} uses a molecules data file (included in the code).  Lastly,
 an optional opacity file can be used to provide a pre-calculated table
 of opacities (this file can be created by {\transit} itself).
@@ -648,8 +648,8 @@ execute: \newline
 \argument{{-}{-}linedb=$<$linedb$>$}{Input line information (TLI) file(s)
   (as given by `pylineread').}
 
-\argument{{-}{-}cia=$<$filenames$>$}{Input collision-induced absorption
-  (CIA) opacities file(s) (comma-separated list if more than one
+\argument{{-}{-}csfile=$<$filenames$>$}{Input cross-section opacities file(s)
+  (comma-separated list if more than one
   file).}
 
 \argument{{-}{-}outtoomuch=$<$filename$>$}{Ouput file to store the depth
@@ -997,8 +997,8 @@ transit configuration file, which is further explained below: \newline
 atm    /home/.../HD209458b_atm.tea
 # Path to transit line information (TLI) file:
 linedb /home/.../HITRAN_CH4.tli
-# Path to collision induced absorption (CIA) file:
-cia    /home/.../h2h2.dat
+# Path to cross-section (CS) file:
+csfile /home/.../h2h2.dat
 
 # ::::::::::  Spectrum sampling  :::::::::::::::::::::::::::::::::::::
 # Lowest wavelength boundary (also can be set as the wavenumber
@@ -1120,14 +1120,14 @@ and weighted oscillator strength), mass, isotopic ratio, and a
 tabulated partition-function array as function of temperature for each
 one.  The TLI file is the output of the {\pylineread} module.
 
-\subsubsection{CIA File}
+\subsubsection{Cross-section File}
 
-The CIA file provides tabulated collision-induced absorption data for
-Transit.  CIA data can be obtained from Aleksandra Borysow's webpage
+The cross-section files provide tabulated absorption data for
+Transit (e.g., for collision-induced absorption, CIA).  CIA data can be obtained from Aleksandra Borysow's webpage
 (\href{http://www.astro.ku.dk/~aborysow/programs/index.html}
 {astro.ku.dk/{\sim}aborysow/programs/index.html}).
 See below (and {\tttm
-  transit/inputs/CIA\_H2H2\_400-7000K.dat}) for a CIA file sample:
+  transit/inputs/CIA\_H2H2\_400-7000K.dat}) for a CS file sample:
 \newline
 \begin{plain}
 # CIA Header for H2-H2:
@@ -1142,7 +1142,7 @@ t         1000      2000      3000      4000      5000      6000      7000
 20000.00  0.269E-14 0.567E-12 0.597E-11 0.205E-10 0.382E-10 0.103E-09 0.144E-09
 \end{plain}
 
-A valid CIA file is a plain text file that contains a
+A valid CS file is a plain text file that contains a
 header and a main body.  Comment lines (starting with the `{\tttm \#}'
 character) and blank lines are allowed and ignored by {\transit}.  The
 header must contain two keyword arguments.  A line starting with the
@@ -1150,10 +1150,11 @@ header must contain two keyword arguments.  A line starting with the
 blank spaces (names should match those from the atmospheric file).  A
 line starting with the `{\tttm t}' keyword contains the list of
 temperatures (blank-space separated, in Kelvin degrees) sampled in the
-CIA file.
+CS file.
 
-The body of the CIA file contains a tabulated list with the absorption
-coefficients (in units of cm$\sp{-1}$ amagat$\sp{-2}$) evaluated as a
+The body of the CS file contains a tabulated list with the absorption
+coefficients (in units of cm$\sp{-1}$ amagat$\sp{-2}$ for CIA data,
+or cm$\sp{-1}$ amagat$\sp{-1}$ for line-transition data) evaluated as a
 function of wavenumber (in units of cm$\sp{-1}$) and temperature.
 Each line contains the wavenumber (first column) and the coefficient
 corresponding to the temperatures specified in the header (values
@@ -1614,7 +1615,7 @@ execution): \\
 \routine{readlineinfo.c}{Read and process the input TLI
   (transition-lines information) file.}
 
-\routine{cia.c}{Read and process the collision-induced-absorption
+\routine{crosssec.c}{Read and process the cross-section absorption
   files.}
 
 \routine{idxrefraction.c}{Calculate the index of refraction of the

--- a/transit/Makefile
+++ b/transit/Makefile
@@ -34,7 +34,7 @@ SCRIPTS_DIR = ./scripts/
 # Files to be compiled
 #
 C_FILES = argum \
-					cia \
+					crosssec \
 					eclipse \
 					extinction \
 					geometry \

--- a/transit/examples/demo/transit_demo.cfg
+++ b/transit/examples/demo/transit_demo.cfg
@@ -7,11 +7,11 @@
 
 # :::::::::: Input files :::::::::::::::::::::::::::::::::::::::::::::
 # Path to atmospheric file:
-atm    ../transit/transit/examples/demo/HD209458b_demo.atm
+atm     ../transit/transit/examples/demo/HD209458b_demo.atm
 # Path to transit-line-information (TLI) file:
-linedb ./CH4_HITRAN_2-4um.tli
-# Path to collision-induced-absorption (CIA) file:
-cia    ../transit/inputs/CIA_H2H2_400-7000K.dat
+linedb  ./CH4_HITRAN_2-4um.tli
+# Path to cross-section (CS) files (comma-separated if more than one file):
+csfile  ../transit/inputs/CIA_H2H2_400-7000K.dat
 # Path to molecular information file:
 molfile ../transit/inputs/molecules.dat
 

--- a/transit/examples/example01_2013-11-26/README_example01
+++ b/transit/examples/example01_2013-11-26/README_example01
@@ -1,3 +1,8 @@
+:::::::::::::: WARNING ::::::::::::::::::::::::::::::::::::::::::::::
+  Note that this Example is terribly outdates.
+  Nobody should use it!
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
 This is the example run number 01:
 It runs a transit for a basic configuration (config_example01.cfg) to
 calculate the spectrum between wavelengths 2.5 and 3.5 microns.

--- a/transit/include/crosssec.h
+++ b/transit/include/crosssec.h
@@ -5,10 +5,10 @@
 #endif
 
 /* src/cia.c */
-extern int readcia P_((struct transit *tr));
-extern int interpolatecia P_((struct transit *tr));
+extern int readcs P_((struct transit *tr));
+extern int interpcs P_((struct transit *tr));
 extern int bicubicinterpolate P_((double **res, double **src, double *x1, long nx1, double *x2, long nx2, double *t1, long nt1, double *t2, long nt2));
-extern void ciaerr P_((int max, char *name, int line));
-extern int freemem_cia P_((struct cia *cia, long *pi));
+extern void cserr P_((int max, char *name, int line));
+extern int freemem_cs P_((struct cross *cross, long *pi));
 
 #undef P_

--- a/transit/include/flags_tr.h
+++ b/transit/include/flags_tr.h
@@ -106,7 +106,7 @@
 /* Progress indicator flags:                                                */
 #define TRPI_READINFO     0x000001  /* readinfofile()   completed           */
 #define TRPI_READDATA     0x000002  /* readdatarng()    completed           */
-#define TRPI_CHKRNG       0x000004  /* checkrange()     completed           */
+#define TRPI_READBIN      0x000004  /* readtli_bin()    completed           */
 #define TRPI_GETATM       0x000008  /* getatm()         completed           */
 #define TRPI_MAKERAD      0x000010  /* makeradsample()  completed           */
 #define TRPI_MAKEWAV      0x000020  /* makewavsample()  completed           */

--- a/transit/include/flags_tr.h
+++ b/transit/include/flags_tr.h
@@ -103,25 +103,25 @@
 #define TRU_EXTBITS     0x00f00000 /* FINDME                                */
 #define TRU_TAUBITS     0x0f000000 /* FINDME                                */
 
-/* Progress indicator flags:  */
-#define TRPI_READINFO     0x000001 /* readinfofile()   completed */
-#define TRPI_READDATA     0x000002 /* readdatarng()    completed */
-#define TRPI_CHKRNG       0x000004 /* checkrange()     completed */
-#define TRPI_GETATM       0x000008 /* getatm()         completed */
-#define TRPI_MAKERAD      0x000010 /* makeradsample()  completed */
-#define TRPI_MAKEWAV      0x000020 /* makewavsample()  completed */
-#define TRPI_MAKEWN       0x000040 /* makewnsample()   completed */
-#define TRPI_MAKEIP       0x000080 /* makeipsample()   completed */
-#define TRPI_MAKETEMP     0x000100 /* maketempsample() completed */
-#define TRPI_IDXREFRAC    0x000200 /* idxrefrac()      completed */
-#define TRPI_EXTWN        0x000400 /* extwn()          completed */
-#define TRPI_TAU          0x000800 /* tau()            completed */
-#define TRPI_GEOMETRY     0x001000 /* setgeom()        completed */
-#define TRPI_GEOMETRYHINT 0x002000 /* setgeomhint()    completed */
-#define TRPI_MODULATION   0x004000 /* modulation()     completed */
-#define TRPI_CIA          0x008000 /* interpolatecia() completed */
-#define TRPI_GRID         0x010000 /* intens_grid()    completed */
-#define TRPI_OPACITY      0x020000 /* idxrefrac()      completed */
+/* Progress indicator flags:                                                */
+#define TRPI_READINFO     0x000001  /* readinfofile()   completed           */
+#define TRPI_READDATA     0x000002  /* readdatarng()    completed           */
+#define TRPI_CHKRNG       0x000004  /* checkrange()     completed           */
+#define TRPI_GETATM       0x000008  /* getatm()         completed           */
+#define TRPI_MAKERAD      0x000010  /* makeradsample()  completed           */
+#define TRPI_MAKEWAV      0x000020  /* makewavsample()  completed           */
+#define TRPI_MAKEWN       0x000040  /* makewnsample()   completed           */
+#define TRPI_MAKEIP       0x000080  /* makeipsample()   completed           */
+#define TRPI_MAKETEMP     0x000100  /* maketempsample() completed           */
+#define TRPI_IDXREFRAC    0x000200  /* idxrefrac()      completed           */
+#define TRPI_EXTWN        0x000400  /* extwn()          completed           */
+#define TRPI_TAU          0x000800  /* tau()            completed           */
+#define TRPI_GEOMETRY     0x001000  /* setgeom()        completed           */
+#define TRPI_GEOMETRYHINT 0x002000  /* setgeomhint()    completed           */
+#define TRPI_MODULATION   0x004000  /* modulation()     completed           */
+#define TRPI_CS           0x008000  /* readcs()         completed           */
+#define TRPI_GRID         0x010000  /* intens_grid()    completed           */
+#define TRPI_OPACITY      0x020000  /* idxrefrac()      completed           */
 
 /* flags for transiterror:  */
 #define TERR_MESSAGE      0x000000

--- a/transit/include/structures_tr.h
+++ b/transit/include/structures_tr.h
@@ -18,14 +18,6 @@
  * 02111-1307, USA.
  */
 
-/* Initial version January 23rd, 2014 Jasmina Blecic
-                   implemented eclipse                                     */
-/* Revision        March 19th,   2014 Jasmina Blecic
-                   implemented switch eclipse/transit                      */
-/* Revision        April 26th,   2014 Jasmina Blecic
-                   implemented intensity grid and flux                     */
-
-
 #ifndef _TRANSIT_STRUCTURES_H
 #define _TRANSIT_STRUCTURES_H
 
@@ -311,15 +303,15 @@ struct detailout{
 };
 
 
-struct cia{
-  int nfiles;         /* Number of CIA files                                */
-  PREC_CIA **e;       /* Extinction from all CIA sources [wn][temp]         */
-  PREC_CIA ***cia;    /* Tabulated CIA extinction    [nfiles][nwave][ntemp] */
-  PREC_CIA **wn;      /* Tabulated wavenumber  arrays  [nfiles][nwave]      */
-  PREC_CIA **temp;    /* Tabulated temperature arrays  [nfiles][ntemp]      */
-  int *nwave;         /* Number of wavenumber samples  [nfiles]             */
-  int *ntemp;         /* Number of temperature samples [nfiles]             */
-  int *mol1, *mol2;   /* Pairs of molecule's ID        [nfiles]             */
+struct cross{
+  int nfiles;         /* Number of cross-section files                      */
+  PREC_CS **e;        /* Extinction from all CS sources [nwn][nrad]         */
+  PREC_CS ***cs;      /* Tabulated CS extinction     [nfiles][nwave][ntemp] */
+  PREC_CS **wn;       /* Tabulated wavenumber arrays [nfiles][nwave]        */
+  PREC_CS **temp;     /* Tabulated temperatures      [nfiles][ntemp]        */
+  int *nwave;         /* Number of wavenumbers       [nfiles]               */
+  int *ntemp;         /* Number of temperatures      [nfiles]               */
+  int *mol1, *mol2;   /* Pairs of molecule's ID      [nfiles]               */
   double tmin, tmax;  /* CIAs minimum and maximum temperatures              */
 };
 
@@ -372,8 +364,8 @@ struct transithint{
   struct detailout det;
 
   double ethresh;       /* Lower extinction-coefficient threshold            */
-  char **ciafile;
-  int ncia;
+  char **csfile;
+  int ncross;
 
 };
 
@@ -446,7 +438,7 @@ struct transit{
     struct extcloud    *cl;
     struct extscat     *sc;
     struct detailout   *det;
-    struct cia         *cia;
+    struct cross       *cross;
   }ds;
 };
 

--- a/transit/include/structures_tr.h
+++ b/transit/include/structures_tr.h
@@ -124,12 +124,9 @@ struct lineinfo{             /* Line information parameters:                */
   unsigned short tli_ver;    /* TLI version                                 */
   unsigned short lr_ver;     /* lineread version                            */
   unsigned short lr_rev;     /* lineread revision                           */
-  prop_samp wavs;            /* Wavelength sampling                         */
   double wi, wf;             /* Initial and final wavelength in database    */
   long endinfo;              /* Position at the end of the info part
                                 of the info file                            */
-  int asciiline;             /* TLI line of first transition.
-                                Zero if a binary file.                      */
   int ni;                    /* Number of isotopes                          */
   int ndb;                   /* Number of databases                         */
   prop_isov *isov;           /* Variable isotope information (w/temp) [iso] */

--- a/transit/include/structures_tr.h
+++ b/transit/include/structures_tr.h
@@ -311,7 +311,8 @@ struct cross{
   PREC_CS **temp;     /* Tabulated temperatures      [nfiles][ntemp]        */
   int *nwave;         /* Number of wavenumbers       [nfiles]               */
   int *ntemp;         /* Number of temperatures      [nfiles]               */
-  int *mol1, *mol2;   /* Pairs of molecule's ID      [nfiles]               */
+  int *nspec;         /* Number of species           [nfiles]               */
+  int **mol;          /* Species' ID for each file   [nfiles][2]            */
   double tmin, tmax;  /* CIAs minimum and maximum temperatures              */
 };
 

--- a/transit/include/transit.h
+++ b/transit/include/transit.h
@@ -178,7 +178,7 @@ extern void freemem_transit P_((struct transit *tr));
 #include <tau.h>
 #include <argum.h>
 #include <geometry.h>
-#include <cia.h>
+#include <crosssec.h>
 #include <eclipse.h>
 #include <slantpath.h>
 #endif /* _TRANSIT_H */

--- a/transit/include/types_tr.h
+++ b/transit/include/types_tr.h
@@ -21,14 +21,13 @@
 #ifndef _TYPES_TR_H
 #define _TYPES_TR_H
 
-/*  Types  */
-#define PREC_NSAMP int      /* Type for radius and wavelength indices       */
-#define PREC_NREC long      /* Type for record indices                      */
-#define PREC_ZREC double    /* Type for the partition info                  */
+/* Data types:                                                              */
+#define PREC_NSAMP  int     /* Type for radius and wavelength indices       */
+#define PREC_NREC   long    /* Type for record indices                      */
+#define PREC_ZREC   double  /* Type for the partition info                  */
 #define PREC_LNDATA double  /* Type for the line data output                */
-#define PREC_RES double     /* Type for every partial result                */
-#define PREC_ATM double     /* Type for atmospheric data                    */
-#define PREC_CS  double     /* Type for cross-section                       */
-#define PREC_CIA double     /* Type for collision induced absorption        */
+#define PREC_RES    double  /* Type for every partial result                */
+#define PREC_ATM    double  /* Type for atmospheric data                    */
+#define PREC_CS     double  /* Type for cross-section data                  */
 
 #endif /* _TYPES_TR_H */

--- a/transit/scripts/setup.py
+++ b/transit/scripts/setup.py
@@ -9,7 +9,8 @@ pu  = op.realpath(op.join(op.dirname(\
 
 
 transit_module = Extension('_transit_module',sources=['src/transit_wrap.c'],
-                            extra_objects=[op.join(src,'argum.o'),op.join(src,'cia.o'),
+                            extra_objects=[op.join(src,'argum.o'),
+                                           op.join(src,'crosssec.o'),
                                            op.join(src,'eclipse.o'),
                                            op.join(src,'extinction.o'),
                                            op.join(src,'geometry.o'),

--- a/transit/src/argum.c
+++ b/transit/src/argum.c
@@ -130,7 +130,7 @@ processparameters(int argc,            /* Number of command-line args  */
     CLA_DETEXT,
     CLA_DETCIA,
     CLA_DETTAU,
-    CLA_CIAFILE,
+    CLA_CSFILE,
     CLA_SAVEEXT,
     CLA_STARRAD,
     CLA_SOLUTION_TYPE,
@@ -303,9 +303,9 @@ processparameters(int argc,            /* Number of command-line args  */
     {"detailcia",  CLA_DETCIA,      required_argument, NULL,
      "filename:wn1,wn2,...",
      "Save extinction due to CIA at specified wavenumbers in filename."},
-    {"cia",        CLA_CIAFILE,     required_argument, NULL,    "filenames",
-     "Use the indicated filenames for CIA opacities, it is a comma"
-     "separated list."},
+    {"csfile",      CLA_CSFILE,      required_argument, NULL,    "filenames",
+     "Use the indicated filenames for cross-section opacities (comma-"
+     "separated list)."},
     {"saveext",    CLA_SAVEEXT,     required_argument, NULL,    "filename",
      "Save extinction array in this file which won't need to be recomputed "
      "if only the radius scale (scale height) changes."},
@@ -414,11 +414,12 @@ processparameters(int argc,            /* Number of command-line args  */
     /* Print info to screen if debugging:   */
     transitDEBUG(21, verblevel, "Processing option '%c' / %d, argum: %s\n",
                  rn, rn, optarg);
-    /* Handle each case: */
+    /* Handle each case:                                                    */
     switch(rn){
-    case CLA_CIAFILE:
-      hints->ncia    = nchar(optarg, ',') + 1;        /* Count files */
-      hints->ciafile = splitnzero_alloc(optarg, ','); /* Get files   */
+    /* Cross-section data files:                                            */
+    case CLA_CSFILE:
+      hints->ncross  = nchar(optarg, ',') + 1;        /* Count files        */
+      hints->csfile = splitnzero_alloc(optarg, ',');  /* Get file names     */
       break;
     case CLA_SAVEEXT:  /* Extinction array    */
       hints->save.ext = xstrdup(optarg);
@@ -873,8 +874,8 @@ savehint(FILE *out,
   savestr(out, hints->f_toomuch);
   savestr(out, hints->f_outsample);
   savestr(out, hints->solname);
-  for(int i=0; i<hints->ncia; i++){
-    savestr(out, hints->ciafile[i]);
+  for(int i=0; i<hints->ncross; i++){
+    savestr(out, hints->csfile[i]);
   }
 
   /* Save sub-structures:                                                   */
@@ -922,8 +923,8 @@ resthint(FILE *in,
   if(rn<0) return rn; else res += rn;
   rn = reststr(in, &hint->solname);
   if(rn<0) return rn; else res += rn;
-  for(int i=0; i<hint->ncia; i++){
-    rn = reststr(in, hint->ciafile+i);
+  for(int i=0; i<hint->ncross; i++){
+    rn = reststr(in, hint->csfile+i);
     if(rn<0) return rn; else res += rn;
   }
 
@@ -974,9 +975,9 @@ freemem_hints(struct transithint *h){
 
   /* Free other strings:                                                    */
   free(h->solname);
-  if (h->ncia){
-    free(h->ciafile[0]);
-    free(h->ciafile);
+  if (h->ncross){
+    free(h->csfile[0]);
+    free(h->csfile);
   }
 
   /* Free sub-structures:                                                   */

--- a/transit/src/argum.c
+++ b/transit/src/argum.c
@@ -185,7 +185,7 @@ processparameters(int argc,            /* Number of command-line args  */
     {"atm",        CLA_ATMOSPHERE, required_argument, "NULL",  "atmfile",
      "File containing atmospheric info (Radius, pressure, temperature). A dash"
      " (-) indicates alternative input."},
-    {"linedb",     CLA_LINEDB,     required_argument, "NULL",
+    {"linedb",     CLA_LINEDB,     required_argument, NULL,
      "linedb", "File containing line information (TLI format, as given by "
                "'pylineread'."},
     {"outtoomuch", CLA_OUTTOOMUCH, required_argument, NULL, "filename",

--- a/transit/src/crosssec.c
+++ b/transit/src/crosssec.c
@@ -344,16 +344,11 @@ interpcs(struct transit *tr){
       for(k=0; k < cross->nspec[n]; k++){
         icsmol = cross->mol[n][k];
         dens *= mol->molec[icsmol].d[i] / (AMU * mol->mass[icsmol] * AMAGAT);
-        //if (i == 0)
-          //transitprint(1,2,"%.5e  %.5e\n", mol->molec[icsmol].d[i],
-          //                                 mol->mass[icsmol]);
       }
-      //transitprint(1, 2, "%.2e, ", dens);
-      //transitprint(1, 2, "%.2e, ", dens*e[0][i]);
-      for(j=0; j < tr->wns.n; j++)
+      for(j=0; j < tr->wns.n; j++){
         cross->e[j][i] += e[j][i] * dens;
+      }
     }
-    //transitprint(1, 2, "\n");
   }
   free(e[0]);
   free(e);
@@ -398,18 +393,18 @@ bicubicinterpolate(double **res,  /* target array [t1][t2]                  */
 
   /* Find indices where requested array values are within source boundaries.
      (i.e., do not extrapolate):                                            */
-  while(t1[fi++]<fx1);
+  while(t1[fi++] < fx1);
   fi--;
 
   for(i=0; i<li; i++)
-    if(t1[i]>lx1)
+    if(t1[i] > lx1)
       li = i;
 
-  while(t2[fj++]<fx2);
+  while(t2[fj++] < fx2);
   fj--;
 
   for(j=0; j<lj; j++)
-    if(t2[j]>lx2)
+    if(t2[j] > lx2)
       lj = j;
 
   /* Arrays created by spline_init to be used in interpolation calculation: */

--- a/transit/src/extinction.c
+++ b/transit/src/extinction.c
@@ -196,7 +196,7 @@ extwn(struct transit *tr){
   struct extinction *ex = &st_ex;
   int i;
 
-  /* Check these routines have been called: */
+  /* Check these routines have been called:                                 */
   transitcheckcalled(tr->pi, "extwn", 4,
                              "readinfo_tli",  TRPI_READINFO,
                              "readdatarng",   TRPI_READDATA,
@@ -229,9 +229,8 @@ extwn(struct transit *tr){
   /* FINDME: This should not be a condition, we may want
      to calculate an atmosphere with only CIA for example.                  */
   if(niso < 1){
-    transiterror(TERR_SERIOUS|TERR_ALLOWCONT,
-                 "You are requiring a spectra of zero isotopes!.\n");
-    return -5;
+    transiterror(TERR_WARNING,
+                 "You are requiring a spectra of zero isotopes.\n");
   }
 
   /* Get the extinction coefficient threshold:                              */

--- a/transit/src/makesample.c
+++ b/transit/src/makesample.c
@@ -481,9 +481,11 @@ makeradsample(struct transit *tr){
     tr->pi &= ~(TRPI_MAKERAD);
   }
   /* Check that variables are not NULL:                                     */
-  transitASSERT(atms->rads.n<1 || !ndb || !niso || !nmol,
+  transitASSERT(atms->rads.n<1 || !nmol,
+  //transitASSERT(atms->rads.n<1 || !ndb || !niso || !nmol,
                 "makeradsample():: called but essential variables are "
-                "missing (%d, %d, %d, %d).\n", atms->rads.n, ndb, niso, nmol);
+                "missing (%d, %d).\n", atms->rads.n, nmol);
+                //"missing (%d, %d, %d, %d).\n", atms->rads.n, ndb, niso, nmol);
 
   /* Set interpolation function flag:                                       */
   flag = tr->interpflag;

--- a/transit/src/opacity.c
+++ b/transit/src/opacity.c
@@ -113,7 +113,6 @@ opacity(struct transit *tr){
     freemem_linetransition(&tr->ds.li->lt, &tr->pi);
     tr->pi |= TRPI_READDATA;
     tr->pi |= TRPI_READINFO;
-    tr->pi |= TRPI_CHKRNG;
 
     /* Set progress indicator and return success:                           */
     tr->pi |= TRPI_OPACITY;

--- a/transit/src/readatm.c
+++ b/transit/src/readatm.c
@@ -599,11 +599,11 @@ readatmfile(FILE *fp,                /* Atmospheric file                    */
                                    mol->mass[2], at->atm.p[r]*at->atm.pfct,
                                    at->atm.t[r]*at->atm.tfct);
     }
-    for(i=0; i<at->n_aiso; i++)
+    for(i=0; i<at->n_aiso; i++){
       molec[i].d[r] = stateeqnford(at->mass, molec[i].q[r], at->mm[r],
                                    mol->mass[i], at->atm.p[r]*at->atm.pfct,
                                    at->atm.t[r]*at->atm.tfct);
-    transitprint(30, verblevel, "dens[%2li]: %.14f,   ", r, molec[2].d[r]);
+    }
     r++;
   }
 

--- a/transit/src/tau.c
+++ b/transit/src/tau.c
@@ -209,7 +209,7 @@ tau(struct transit *tr){
     transitprint(1, verblevel, "Computing extinction at outermost layer.\n");
     if (tr->fp_opa != NULL)
       rn = interpolmolext(tr, rnn-1, ex->e);
-    else{
+    else if (tr->f_line != NULL){
       for (i=0; i < tr->ds.mol->nmol; i++)
         density[i] = tr->ds.mol->molec[i].d[rnn-1];
       for (i=0; i < tr->ds.iso->n_i; i++)
@@ -275,7 +275,7 @@ tau(struct transit *tr){
                                         lastr+1, r[lastr]*rfct);
             if (tr->fp_opa != NULL)
               rn = interpolmolext(tr, lastr, ex->e);
-            else{
+            else if (tr->f_line != NULL){
               for (i=0; i < tr->ds.mol->nmol; i++)
                 density[i] = tr->ds.mol->molec[i].d[lastr];
               for (i=0; i < tr->ds.iso->n_i; i++)

--- a/transit/src/transit.c
+++ b/transit/src/transit.c
@@ -118,9 +118,9 @@ void transit_init(int argc, char **argv){
   fw(opacity, <0, &transit);
   t0 = timecheck(verblevel, itr,  5, "opacity", tv, t0);
 
-  /* Initialize CIA:                                                        */
-  fw(readcia, !=0, &transit);
-  t0 = timecheck(verblevel, itr,  6, "readcia", tv, t0);
+  /* Initialize Cross section:                                              */
+  fw(readcs, !=0, &transit);
+  t0 = timecheck(verblevel, itr,  6, "readcs", tv, t0);
   init_run = 1;
 }
 
@@ -167,9 +167,9 @@ void do_transit(double * transit_out){
       transitprint(7, verblevel, "makeipsample() modified some of the hinted "
                                  "parameters. Flag: 0x%lx.\n", fw_status);
 
-    /* Interpolate CIA:                                                     */
-    fw(interpolatecia, !=0, &transit);
-    t0 = timecheck(verblevel, itr,  9, "interpolatecia", tv, t0);
+    /* Interpolate the cross section:                                       */
+    fw(interpcs, !=0, &transit);
+    t0 = timecheck(verblevel, itr,  9, "interpcs", tv, t0);
 
     /* Compute index of refraction:                                         */
     fw(idxrefrac, !=0, &transit);
@@ -241,16 +241,15 @@ void do_transit(double * transit_out){
 }
 
 void free_memory(void){
-  /* This function frees all the memory used in transit, and should be
+  /* Free all the memory used in transit, and should be
      called at the end of the program. Check if all these data structures
-     can be used when called from bart, In MPItransit not all the frees
-     happen.                                                                */
+     can be used when called from bart.                                     */
   freemem_molecules( transit.ds.mol, &transit.pi);
   freemem_atmosphere(transit.ds.at,  &transit.pi);
   if (transit.fp_opa == NULL)
     freemem_linetransition(&transit.ds.li->lt,  &transit.pi);
-  freemem_lineinfo(  transit.ds.li,  &transit.pi);
-  freemem_cia(       transit.ds.cia, &transit.pi);
+  freemem_lineinfo(transit.ds.li,  &transit.pi);
+  freemem_cs(transit.ds.cross,     &transit.pi);
   freemem_transit(&transit);
   init_run = 0;
 }


### PR DESCRIPTION
Enabled cross-section data (opacity as function of wavelength) for CIA and lin-transition data.
Enabled runs without a TLI file.
Renamed cia arguments into csfile.
Updated user-manual documentation.
Resolves #96.
