### PR TITLE
Simplify text output scheme.

### DIFF
--- a/doc/transit_code_manual/transit_code_manual.tex
+++ b/doc/transit_code_manual/transit_code_manual.tex
@@ -1023,12 +1023,12 @@ inline void transitdot(int thislevel, int verblevel, ...)}
 \tgray{Print a '.' character.} \newline
 
 \function{
-int transiterror\_fcn(int flags, const char *file, const long line, const char *str, ...)}
-\tgray{Set up additional arguments and call the error function.} \newline
+int tr\_output\_fcn(int flags, const char *file, const long line, const char *str, ...)}
+\tgray{Set up additional arguments and call the output function.} \newline
 
 \function{
-int vtransiterror\_fcn(int flags, const char *file, const long line, const char *str, \\ va\_list ap)}
-\tgray{Error function for {\tt transit}.} \newline
+int tr\_output\_vfcn(int flags, const char *file, const long line, const char *str, \\ va\_list format)}
+\tgray{Output, error, and debug function for {\tt transit}.} \newline
 
 \function{
 int fileexistopen(char *in, FILE **fp)}
@@ -1094,38 +1094,22 @@ void linetoolong(int max, char *file, int line)}
 double timecheck(int verblevel, long iter, long index, char *str, \\ struct timeval tv, double t0)}
 \tgray{Print to screen the time since given time (t0).} \newline
 
-\subsubsection{transiterror\_fcn:}
+\subsubsection{tr_output\_fcn:}
 \paragraph{Walkthrough}
 \begin{enumerate}[leftmargin=10pt, noitemsep, parsep=0pt, topsep=0ex]
 \item[-] Initialize variable arguments list.
-\item[-] Call to \ttblue{vtransiterror\_fcn} from transitstd.c to print the error message and exit (unless indicated to continue).
+\item[-] Call to \ttblue{tr\_output\_fcn} from transitstd.c to print the message with any decoration necessary.
 \item[-] End using the variable arguments list.
-\item[-] Return the return of \ttblue{vtransiterror\_fcn}.
 \end{enumerate}
 
-\subsubsection{vtransiterror\_fcn:}
+\subsubsection{tr\_output\_vfcn:}
 \paragraph{Walkthrough}
 \begin{enumerate}[leftmargin=10pt, noitemsep, parsep=0pt, topsep=0ex]
-\item[-] Set up all the parts of the error message to be printed.
-\item[-] If specified that no warnings should be given, return 0.
-\item[-] Set the length of the error to the length of the first line of the error message.
-\item[-] If the user has not specified that they want no error preamble, add the legnth of the error preamble and post-error message to the length of the total error message.
-\item[-] If in debug mode, add the length of debug message to the error message length.
-\item[-] Add the length of the specific error string to the error message length.
-\item[-] Allocate memory for the error message and 
-\item[-] If the error preamble is desired, append it to the error message.
-\item[-] Append the pre-error message to the error message.
-\item[-] If in debug mode, print the debug message and append the debug message to the error message.
-\item[-] If the error preamble is desired, append the error type to the error message.
-\item[-] Append the specific error string to the error message.
-\item[-] If the error preamble is desired, append the post-error message to the error message.
-\item[-] Compose the error message string using the specifiec variable arguments and store in output.
-\item[-] If an error occurred in composition, reallocate the size of the output and compose the error message again.
-\item[-] Free the error message
-\item[-] Print the output (the composed error message).
-\item[-] Free the output.
-\item[-] If the program is allowed to continue despite the error, increment the number of error encountered and return the size of the output.
-\item[-] Exit program.
+\item[-] Decide the output stream to use: errors go to stderr, and all other messages go to stdout.
+\item[-] If a banner was requested by the caller to make the message stand out, print the header line.
+\item[-] Errors, warnings, and other messages with the TOUT_LOCATE flag have the file and line number printed.
+\item[-] Print the given message.
+\item[-] If a banner was requested, print the footer line.
 \end{enumerate}
 
 \subsubsection{fileexistopen:}
@@ -1165,7 +1149,7 @@ double timecheck(int verblevel, long iter, long index, char *str, \\ struct time
 \item[-] Check each given function against the progress indicator.
 \item[-] If one of the functions has not been called, append the error message.
 \item[-] Append the names of the functions not called.
-\item[-] Call \ttblue{transiterror} to print the error.
+\item[-] Call \ttblue{tr\_output} to print the error.
 \end{enumerate}
 
 \subsubsection{error:}

--- a/doc/transit_code_manual/transit_code_manual.tex
+++ b/doc/transit_code_manual/transit_code_manual.tex
@@ -907,7 +907,6 @@ void freemem\_transit(struct transit *tr)}
 \item[-] Call \ttblue{processparameters} from argum.c to process the command line arguments and store them in the hint structure.
 \item[-] Call \ttblue{acceptgenhints} from argum.c to accept general hints from the hint structure.
 \item[-] Call \ttblue{printintro} from argum.c to print the introductory message.
-\item[-] Turn off program warnings if verbosity is sufficiently low.
 \item[-] Call \ttblue{makewnsample} from makesample.c to create the wavenumber sampling.
 \item[-] Call \ttblue{getatm} from readatm.c to read the atmospheric file.
 \item[-] Call \ttblue{readlineinfo} from readlineinfo.c to read the TLI file.

--- a/doc/transit_user_manual/transit_user_manual.tex
+++ b/doc/transit_user_manual/transit_user_manual.tex
@@ -419,7 +419,7 @@ execute: \newline
 \argument{-v VERB, {-}{-}verbose-level VERB}{Verbosity level
   (Integer) [default: 2].}
 
-\argument{-q, {-}{-}quiet}{Set verbosity level to 0.}
+\argument{-q, {-}{-}quiet}{Set verbosity level to 1.}
 
 {\bf Database Arguments:} \newline
 \argument{-o OUTPUT, {-}{-}output OUTPUT}{Output TLI filename (string)
@@ -1046,8 +1046,8 @@ tempdelt    100
 opacityfile  ./opacity_CH4.dat
 
 # ::::::::::  Verbosity Level  :::::::::::::::::::::::::::::::::::::::
-# Level of on-screen verbosity from 1-20 (default: 2)
-verb 11
+# Level of on-screen verbosity from 1-5 (default: 2)
+verb 4
 
 # ::::::::::  Output Files  ::::::::::::::::::::::::::::::::::::::::::
 # Wavelength vs. radius where the optical depth reaches toomuch

--- a/transit/examples/demo/transit_demo.cfg
+++ b/transit/examples/demo/transit_demo.cfg
@@ -48,8 +48,8 @@ ethresh 1e-6
 nwidth 20
 
 # :::::::::: Verbosity :::::::::::::::::::::::::::::::::::::::::::::::
-# Verbosity level for on-screen display (0 -- 20):
-verb 11
+# Verbosity level for on-screen display (1 -- 5):
+verb 4
 
 # :::::::::: Output files ::::::::::::::::::::::::::::::::::::::::::::
 # Radius (at each wavelength sample) where the optical depth == toomuch:

--- a/transit/include/flags_tr.h
+++ b/transit/include/flags_tr.h
@@ -123,17 +123,6 @@
 #define TRPI_GRID         0x010000  /* intens_grid()    completed           */
 #define TRPI_OPACITY      0x020000  /* idxrefrac()      completed           */
 
-/* flags for transiterror:  */
-#define TERR_MESSAGE      0x000000
-#define TERR_CRITICAL     0x000001
-#define TERR_SERIOUS      0x000002
-#define TERR_WARNING      0x000003
-#define TERR_NOFLAGBITS   0x00000f
-#define TERR_ALLOWCONT    0x000010
-#define TERR_NOPREAMBLE   0x000020
-#define TERR_ALLOC        0x000040
-#define TERR_DBG          0x000080
-
 /* Flags for tr_output: */
 #define TOUT_ERROR        0x000001
 #define TOUT_WARN         0x000002

--- a/transit/include/flags_tr.h
+++ b/transit/include/flags_tr.h
@@ -134,6 +134,17 @@
 #define TERR_ALLOC        0x000040
 #define TERR_DBG          0x000080
 
+/* Flags for tr_output: */
+#define TOUT_ERROR        0x000001
+#define TOUT_WARN         0x000002
+#define TOUT_INFO         0x000003
+#define TOUT_RESULT       0x000004
+#define TOUT_DEBUG        0x000005
+
+#define TOUT_VERBMASK     0x00000f
+#define TOUT_LOCATE       0x000010
+#define TOUT_BANNER       0x000020
+
 /* Shared memory flags: */
 #define TSHM_START        0x000000 /* Default state     */
 #define TSHM_INIT         0x000001 /* Space initialized */

--- a/transit/include/transit.h
+++ b/transit/include/transit.h
@@ -134,7 +134,6 @@ long fw_status;
 #define free_null(x) do{free(x);x=NULL;}while(0)
 
 #ifdef NODEBUG_TRANSIT
-#define transitDEBUG(...) ((void)0)
 #define transitASSERT(...) ((void)0)
 #else
 #define free(x)  do{free(x);x=NULL;}while(0)
@@ -144,7 +143,6 @@ long fw_status;
     exit(EXIT_FAILURE); \
   } \
 } while(0)
-#define transitDEBUG(...) transitprint(__VA_ARGS__)
 #endif
 
 /* Maximum name length: */

--- a/transit/include/transit.h
+++ b/transit/include/transit.h
@@ -149,8 +149,7 @@ long fw_status;
 #define _Bool short
 #endif
 
-extern int transit_nowarn;
-extern int verblevel;      /* Verbose level > 10 is only for debuging       */
+extern int verblevel;      /* Verbose level > 4 is only for debuging       */
 extern int maxline;        /* Initialized in transitstd                     */
 extern int version;
 extern int revision;

--- a/transit/include/transit.h
+++ b/transit/include/transit.h
@@ -117,9 +117,6 @@ long fw_status;
     }                                                    \
                                        }while(0)
 
-#define transitprint(thislevel, verblevel, ...) do{                         \
-  if(thislevel <= verblevel)  fprintf(stdout, __VA_ARGS__); }while(0)
-
 /* Add flag to transit if present in hint and change hint flag value:       */
 #define transitacceptflag(transit, hint, flag) do{                          \
         transit |= hint&flag; hint &= ~(flag); }while(0)

--- a/transit/include/transit.h
+++ b/transit/include/transit.h
@@ -88,6 +88,11 @@ stateeqnford(_Bool mass,  /* Abundance by mass (1) or by number (0)         */
   return rho * mi;
 }
 
+#define tr_output(level, verblevel, ...) do { \
+  if (((level) & TOUT_VERBMASK) <= verblevel) tr_output_fcn(level, __FILE__, \
+    __LINE__, __VA_ARGS__); \
+} while(0)
+
 #define DEBUG_ERROR
 #ifdef  DEBUG_ERROR
 #define DBGERR | TERR_DBG

--- a/transit/include/transitstd.h
+++ b/transit/include/transitstd.h
@@ -8,8 +8,6 @@
 extern inline void transitdot P_((int thislevel, int verblevel, ...));
 extern void tr_output_fcn P_((int level, const char *file, const long line, const char *str, ...));
 extern void tr_output_vfcn P_((int level, const char *file, const long line, const char *str, va_list format));
-extern int transiterror_fcn P_((int flags, const char *file, const long line, const char *str, ...));
-extern int vtransiterror_fcn P_((int flags, const char *file, const long line, const char *str, va_list ap));
 extern int fileexistopen P_((char *in, FILE **fp));
 extern FILE *verbfileopen P_((char *in, char *desc));
 extern void transitcheckcalled P_((const long pi, const char *fcn, const int n, ...));

--- a/transit/include/transitstd.h
+++ b/transit/include/transitstd.h
@@ -6,8 +6,8 @@
 
 /* src/transitstd.c */
 extern inline void transitdot P_((int thislevel, int verblevel, ...));
-extern void tr_output_fcn P_((int level, const char *file, const long line, const char *str, ...));
-extern void tr_output_vfcn P_((int level, const char *file, const long line, const char *str, va_list format));
+extern void tr_output_fcn P_((int flags, const char *file, const long line, const char *str, ...));
+extern void tr_output_vfcn P_((int flags, const char *file, const long line, const char *str, va_list format));
 extern int fileexistopen P_((char *in, FILE **fp));
 extern FILE *verbfileopen P_((char *in, char *desc));
 extern void transitcheckcalled P_((const long pi, const char *fcn, const int n, ...));

--- a/transit/include/transitstd.h
+++ b/transit/include/transitstd.h
@@ -6,6 +6,8 @@
 
 /* src/transitstd.c */
 extern inline void transitdot P_((int thislevel, int verblevel, ...));
+extern void tr_output_fcn P_((int level, const char *file, const long line, const char *str, ...));
+extern void tr_output_vfcn P_((int level, const char *file, const long line, const char *str, va_list format));
 extern int transiterror_fcn P_((int flags, const char *file, const long line, const char *str, ...));
 extern int vtransiterror_fcn P_((int flags, const char *file, const long line, const char *str, va_list ap));
 extern int fileexistopen P_((char *in, FILE **fp));

--- a/transit/src/argum.c
+++ b/transit/src/argum.c
@@ -412,8 +412,8 @@ processparameters(int argc,            /* Number of command-line args  */
       break;
 
     /* Print info to screen if debugging:   */
-    transitDEBUG(21, verblevel, "Processing option '%c' / %d, argum: %s\n",
-                 rn, rn, optarg);
+    tr_output(TOUT_DEBUG, "Processing option '%c' / %d, argum: %s\n",
+      rn, rn, optarg);
     /* Handle each case:                                                    */
     switch(rn){
     /* Cross-section data files:                                            */

--- a/transit/src/argum.c
+++ b/transit/src/argum.c
@@ -451,10 +451,12 @@ processparameters(int argc,            /* Number of command-line args  */
       /* Get wavenumbers, parse values into det.ref and how many in det.n: */
       det->n = getad(0, ',', optarg+i, &det->ref);
       /* Check for errors: */
-      if(det->n<1 || i==rn-1)
+      if(det->n<1 || i==rn-1) {
         tr_output(TOUT_ERROR | TOUT_BANNER,
                      "Bad format for detailed %s parameter, no valid "
                      "wavenumbers\n", det->name);
+        exit(EXIT_FAILURE);
+      }
       break;
 
     case CLA_ETHRESH:    /* Minimum extiction-coefficient threshold */
@@ -638,13 +640,13 @@ processparameters(int argc,            /* Number of command-line args  */
         "Unknown, unsupported, or missing parameter to option of "
         "code %i (%s) passed as argument, use '-h' to see the "
         "available options.\n", rn, (char)rn);
-      exit(0);
+      exit(EXIT_FAILURE);
       break;
     default:   /* Ask for syntax help:                                      */
       tr_output(TOUT_ERROR | TOUT_BANNER,
         "Even though option of code %i (%c) had a valid structure "
         "element, it had no switch control statement.\n", rn, (char)rn);
-      exit(0);
+      exit(EXIT_FAILURE);
       break;
     case 'h':  /* Print out doc-string help:                                */
       prochelp(EXIT_SUCCESS);
@@ -682,14 +684,14 @@ processparameters(int argc,            /* Number of command-line args  */
       if(*optarg != ','  ||  optarg[1] == '\0') {
         tr_output(TOUT_ERROR, "Syntax error in option '--cloudrad', "
           "parameters need to be given as cloudext,cloudtop,cloudbot.\n");
-        exit(0);
+        exit(EXIT_FAILURE);
       }
 
       hints->cl.cloudtop = strtod(optarg+1, &optarg);
       if(*optarg != ','  ||  optarg[1] == '\0') {
         tr_output(TOUT_ERROR, "Syntax error in option '--cloudrad', "
           "parameters need to be given as cloudext,cloudtop,cloudbot.\n");
-        exit(0);
+        exit(EXIT_FAILURE);
       }
 
       hints->cl.cloudbot = strtod(optarg+1, NULL);
@@ -699,7 +701,7 @@ processparameters(int argc,            /* Number of command-line args  */
         tr_output(TOUT_ERROR, "Syntax error in '--cloud', the cloud top "
                  "(%g) needs to be larger than the cloud bottom (%g) and both "
                  "greater than 0.\n", hints->cl.cloudtop, hints->cl.cloudbot);
-        exit(0);
+        exit(EXIT_FAILURE);
       }
       break;
     case CLA_INTENS_GRID:    /* Intensity grid                              */

--- a/transit/src/argum.c
+++ b/transit/src/argum.c
@@ -827,8 +827,8 @@ acceptgenhints(struct transit *tr){
     tr_output(TOUT_ERROR, "Invalid sampling function specified.\n");
     exit(EXIT_FAILURE);
   }
-  transitprint(10, verblevel, "transit interpolation flag: %li.\n",
-                               tr->interpflag);
+  tr_output(TOUT_DEBUG,
+    "transit interpolation flag: %li.\n", tr->interpflag);
 
   if (th->r0 < 0){
     tr_output(TOUT_ERROR,
@@ -962,13 +962,13 @@ printintro(){
     snprintf(rcname, 20, "-rc%i", version_rc);
   else
     rcname[0] = '\0';
-  transitprint(1, verblevel,
-               "-----------------------------------------------\n"
-               "                TRANSIT v%i.%i%s\n"
-               "-----------------------------------------------\n",
-               version, revision, rcname);
+  fprintf(stdout,
+    "--------------------------------------------------\n"
+    "                   TRANSIT v%i.%i%s\n"
+    "--------------------------------------------------\n",
+    version, revision, rcname);
   time_t tim = time(NULL);
-  transitprint(2, verblevel, "Started on %s\n", ctime(&tim));
+  tr_output(TOUT_INFO, "Started on %s\n", ctime(&tim));
 }
 
 

--- a/transit/src/crosssec.c
+++ b/transit/src/crosssec.c
@@ -98,8 +98,8 @@ readcs(struct transit *tr){
   if(!nfiles){
     return 0;
   }
-  transitprint(1, verblevel, "Computing cross-section opacities for %i "
-                             "database%s:\n", nfiles, nfiles>1 ? "s":"");
+  tr_output(TOUT_RESULT, "Computing cross-section opacities for %i "
+    "database%s:\n", nfiles, (nfiles > 1 ? "s" : ""));
 
   /* Allocate string for molecule names:                                    */
   colname = (char *)calloc(maxline, sizeof(char));
@@ -128,8 +128,9 @@ readcs(struct transit *tr){
       tr_output(TOUT_ERROR, "Cannot read cross-section file '%s'.\n",file);
       exit(EXIT_FAILURE);
     }
-    transitprint(10, verblevel, "  Cross-section file (%d/%d): '%s'\n",
-                                j+1, nfiles, file);
+    tr_output(TOUT_DEBUG,
+      "  Cross-section file (%d/%d): '%s'\n", (j + 1), nfiles, file);
+
     lines = 0; /* lines read counter                                        */
     lpa   = 0;
     /* Read the file headers:                                               */
@@ -174,16 +175,16 @@ readcs(struct transit *tr){
           lp = nextfield(lp);
         }
 
-        transitprint(10, verblevel, "  Cross-section species: ");
+        tr_output(TOUT_DEBUG, "  Cross-section species: ");
         for (k=0; k<nspec; k++)
-          transitprint(10, verblevel, "%s, ", mol->name[st_cross.mol[j][k]]);
-        transitprint(10, verblevel, "\n");
+          tr_output(TOUT_DEBUG, "%s, ", mol->name[st_cross.mol[j][k]]);
+        tr_output(TOUT_DEBUG, "\n");
         continue;
 
       case 't': /* Read the sampling temperatures array:                    */
         while(isblank(*++lp));
         nt = st_cross.ntemp[j] = countfields(lp, ' ');  /* Number of temps. */
-        transitprint(5, verblevel, "  Number of temperature samples: %ld\n",
+        tr_output(TOUT_DEBUG, "  Number of temperature samples: %ld\n",
                                    nt);
         if(!nt) {
           tr_output(TOUT_ERROR,
@@ -197,11 +198,11 @@ readcs(struct transit *tr){
         st_cross.temp[j] = (PREC_CS *)calloc(nt, sizeof(PREC_CS));
         n = 0;    /* Count temperatures per line                            */
         lpa = lp; /* Pointer in line                                        */
-        transitprint(20, verblevel, "  Temperatures (K) = [");
+        tr_output(TOUT_DEBUG, "  Temperatures (K) = [");
         while(n < nt){
           while(isblank(*lpa++));
           st_cross.temp[j][n] = strtod(--lpa, &lp);  /* Get value           */
-          transitprint(20, verblevel, "%d, ", (int)st_cross.temp[j][n]);
+          tr_output(TOUT_DEBUG, "%d, ", (int)st_cross.temp[j][n]);
           if(lp==lpa) {
             tr_output(TOUT_ERROR,
               "Less fields (%i) than expected (%i) were read for "
@@ -213,7 +214,7 @@ readcs(struct transit *tr){
           lpa = lp;
           n++;
         }
-        transitprint(20, verblevel, "\b\b]\n");
+        tr_output(TOUT_DEBUG, "\b\b]\n");
         continue;
       default:
         break;
@@ -289,12 +290,13 @@ readcs(struct transit *tr){
       for(i=1; i<n; i++)
         a[i] = a[0] + i*nt;
     }
-    transitprint(5, verblevel, "  Number of wavenumber samples: %d\n", n);
-    transitprint(5, verblevel, "  Wavenumber array (cm-1) = [%.1f, %.1f, "
-                               "%.1f, ..., %.1f, %.1f, %.1f]\n",
-                               st_cross.wn[j][  0], st_cross.wn[j][  1],
-                               st_cross.wn[j][  2], st_cross.wn[j][n-3],
-                               st_cross.wn[j][n-2], st_cross.wn[j][n-1]);
+    tr_output(TOUT_DEBUG, "  Number of wavenumber samples: %d\n", n);
+    tr_output(TOUT_DEBUG, "  Wavenumber array (cm-1) = [%.1f, %.1f, "
+      "%.1f, ..., %.1f, %.1f, %.1f]\n",
+      st_cross.wn[j][  0], st_cross.wn[j][  1],
+      st_cross.wn[j][  2], st_cross.wn[j][n-3],
+      st_cross.wn[j][n-2], st_cross.wn[j][n-1]);
+
     /* Wavenumber boundaries check:                                         */
     if ((st_cross.wn[j][  0] > tr->wns.v[          0]) ||
         (st_cross.wn[j][n-1] < tr->wns.v[tr->wns.n-1]) ){
@@ -310,7 +312,7 @@ readcs(struct transit *tr){
     fclose(fp);
   }
   free(colname);
-  transitprint(1, verblevel, "Done.\n");
+  tr_output(TOUT_RESULT, "Done.\n");
   tr->pi |= TRPI_CS;
   return 0;
 }

--- a/transit/src/eclipse.c
+++ b/transit/src/eclipse.c
@@ -292,7 +292,7 @@ emergent_intens(struct transit *tr){  /* Transit structure                  */
   struct optdepth *tau = tr->ds.tau;
 
   /* Integrate for each wavelength:                                         */
-  transitprint(4, verblevel, "Integrating over wavelength.\n");
+  tr_output(TOUT_RESULT, "Integrating over wavelength.\n");
 
   /* Printing process variable:                                             */
   int nextw = wn->n/10;
@@ -318,11 +318,11 @@ emergent_intens(struct transit *tr){  /* Transit structure                  */
     /* Prints to screen the progress status:                                */
     if(w == nextw){
       nextw += wn->n/10;
-      transitprint(10, verblevel, "%i%% ", (10*(int)(10*w/wn->n+0.9999999999)));
+      tr_output(TOUT_DEBUG, "%i%% ", (10*(int)(10*w/wn->n+0.9999999999)));
     }
   }
-
-  transitprint(4, verblevel, "\nDone.\n");
+  tr_output(TOUT_DEBUG, "\n");
+  tr_output(TOUT_RESULT, "Done.\n");
 
   /* Sets progress indicator, and prints output:                             */
   tr->pi |= TRPI_MODULATION; /* FINDME: this is not a modulation calculation */
@@ -412,10 +412,10 @@ printintens(struct transit *tr){
     outf = fopen(our_fileName, "w");
   }
   else{
-    transitprint(1, verblevel, "No intensity file.\n");
+    tr_output(TOUT_WARN, "No intensity file.\n");
     return;
   }
-  transitprint(1, verblevel, "\nPrinting intensity in '%s'\n",
+  tr_output(TOUT_INFO, "\nPrinting intensity in '%s'\n",
                              tr->f_outintens ? our_fileName:"standard output");
 
   /* Print the header:                                                      */
@@ -467,8 +467,8 @@ printflux(struct transit *tr){
   if(tr->f_outflux && tr->f_outflux[0] != '-')
     outf = fopen(our_fileName, "w");
 
-  transitprint(1, verblevel, "\nPrinting flux in '%s'\n",
-               tr->f_outflux ? our_fileName:"standard output");
+  tr_output(TOUT_INFO, "\nPrinting flux in '%s'\n",
+    tr->f_outflux ? our_fileName : "standard output");
 
   /* Print the header:                                                      */
   fprintf(outf, "#wvl [um]%*sFlux [erg/s/cm]\n", 6, " ");

--- a/transit/src/eclipse.c
+++ b/transit/src/eclipse.c
@@ -234,9 +234,11 @@ eclipse_intens(struct transit *tr,  /* Transit structure                    */
     last = rnn;
 
   /* Checks if we have enough radii to do spline, at least 3:               */
-  if(last < 3)
-    transiterror(TERR_CRITICAL, "Less than 3 items (%i given) for radial "
-                                "integration.\n", last);
+  if(last < 3) {
+    tr_output(TOUT_ERROR,
+      "Less than 3 items (%i given) for radial integration.\n", last);
+    exit(EXIT_FAILURE);
+  }
 
   /* Integrate along tau up to tau = toomuch:                               */
   hsum    = calloc(last/2, sizeof(double));

--- a/transit/src/eclipse.c
+++ b/transit/src/eclipse.c
@@ -412,7 +412,7 @@ printintens(struct transit *tr){
     outf = fopen(our_fileName, "w");
   }
   else{
-    tr_output(TOUT_WARN, "No intensity file.\n");
+    tr_output(TOUT_INFO, "No intensity file requested.\n");
     return;
   }
   tr_output(TOUT_INFO, "\nPrinting intensity in '%s'\n",

--- a/transit/src/extinction.c
+++ b/transit/src/extinction.c
@@ -124,7 +124,7 @@ savefile_extinct(char *filename,
     return;
   }
 
-  transitprint(2, verblevel, "Saving extinction file '%s'", filename);
+  tr_output(TOUT_INFO, "Saving extinction file: '%s'\n", filename);
 
   const char mn[] = "@E@S@";
   fwrite(mn, sizeof(char), 5, fp);
@@ -137,7 +137,7 @@ savefile_extinct(char *filename,
   for (i=0 ; i<nrad ; i++)
     if (c[i]) break;
 
-  transitprint(2, verblevel, " done (%li/%li radii computed)\n", nrad-i, nrad);
+  tr_output(TOUT_RESULT, "Done (%li/%li radii computed)\n", nrad-i, nrad);
 }
 
 
@@ -171,7 +171,7 @@ restfile_extinct(char *filename,
      return;
   }
 
-  transitprint(2, verblevel, "Restoring extinction file '%s'", filename);
+  tr_output(TOUT_INFO, "Restoring extinction file: '%s'\n", filename);
 
   fread(e[0], sizeof(PREC_RES), nrad*nwav, fp);
   fread(c,    sizeof(_Bool),    nrad,      fp);
@@ -180,7 +180,7 @@ restfile_extinct(char *filename,
   for (i=0; i<nrad; i++)
     if (c[i]) break;
 
-  transitprint(2, verblevel, " done (From the %lith radii)\n", i);
+  tr_output(TOUT_RESULT, "Done (from the %lith radii)\n", i);
 
   fclose(fp);
 
@@ -436,7 +436,7 @@ computemolext(struct transit *tr, /* transit struct                         */
 
     /* Print Lorentz and Doppler broadening widths:                         */
     if(i <= 0)
-      transitprint(1, verblevel, "Broadening (cm-1): Lorentz: %.5e, Doppler: "
+      tr_output(TOUT_RESULT, "Broadening (cm-1): Lorentz: %.5e, Doppler: "
               "%.5e (T=%.2f).\n", alphal[i], alphad[i]*wn[0], temp);
 
     maxwidth = fmax(alphal[i], alphad[i]*wn[0]); /* Max between Dop and Lor */
@@ -447,7 +447,7 @@ computemolext(struct transit *tr, /* transit struct                         */
     ilor[i] = binsearchapprox(aLor, alphal[i],       0, nLor);
   }
 
-  transitprint(10, verblevel, "Minimum width in layer: %.9f\n", minwidth);
+  tr_output(TOUT_DEBUG, "Minimum width in layer: %.9f\n", minwidth);
   /* Set oversampling resolution:                                           */
   for (i=1; i < tr->ndivs; i++)
     if (tr->odivs[i]*(dwn/tr->owns.o) >= 0.5 * minwidth){
@@ -456,9 +456,9 @@ computemolext(struct transit *tr, /* transit struct                         */
   ofactor = tr->odivs[i-1];         /* Dynamic-sampling oversampling factor */
   ddwn    = odwn * ofactor;         /* Dynamic-sampling grid interval       */
   dnwn    = 1 + (onwn-1) / ofactor; /* Number of dynamic-sampling values    */
-  transitprint(10, verblevel, "Dynamic-sampling grid interval: %.9f  "
+  tr_output(TOUT_DEBUG, "Dynamic-sampling grid interval: %.9f  "
                "(scale factor:%i)\n", ddwn, ofactor);
-  transitprint(10, verblevel, "Number of dynamic-sampling values:%li\n",
+  tr_output(TOUT_DEBUG, "Number of dynamic-sampling values:%li\n",
                                 dnwn);
 
   /* Determine the maximum and minimum line-strength per isotope:           */
@@ -540,10 +540,10 @@ computemolext(struct transit *tr, /* transit struct                         */
     /* Index of closest (but not larger than) dynamic-sampling wavenumber:  */
     idwn = (wavn - tr->wns.i)/ddwn;
 
-    transitprint(1000, 2, "own[nown:%li]=%.3f  (wf=%.3f)\n",
-                          onwn, tr->owns.v[onwn-1], tr->wns.f);
-    transitprint(1000, 2, "wavn=%.3f   own[%i]=%.3f\n",
-                          wavn, iown, tr->owns.v[iown]);
+    // transitprint(1000, 2, "own[nown:%li]=%.3f  (wf=%.3f)\n",
+    //                       onwn, tr->owns.v[onwn-1], tr->wns.f);
+    // transitprint(1000, 2, "wavn=%.3f   own[%i]=%.3f\n",
+    //                       wavn, iown, tr->owns.v[iown]);
 
     /* FINDME: de-hard code this threshold                                  */
     /* Update Doppler width according to the current wavenumber:            */
@@ -565,9 +565,10 @@ computemolext(struct transit *tr, /* transit struct                         */
     if (maxj > dnwn)
       maxj = dnwn;
 
-    transitprint(1000, verblevel, "minj:%li  maxj:%li  subw:%li  offset:%li  "
-                       "index1:%li\nf=np.array([",
-                 minj, maxj, subw, offset, ofactor*minj - offset);
+    tr_output(TOUT_DEBUG, "minj:%li  maxj:%li  subw:%li  offset:%li  "
+      "index1:%li\nf=np.array([",
+      minj, maxj, subw, offset, ofactor*minj - offset);
+
     /* Add the contribution from this line to the opacity spectrum:         */
     /* Adding in more complex but faster array indexing based on simpler
      * pointer arrithmatic                                                  */
@@ -583,12 +584,12 @@ computemolext(struct transit *tr, /* transit struct                         */
   for (m=0; m < Nmol; m++)
     downsample(ktmp[m], kiso[m], dnwn, tr->owns.o/ofactor);
 
-  transitprint(9, verblevel, "Number of co-added lines:     %8li  (%5.2f%%)\n",
-                             nadd,  nadd*100.0/nlines);
-  transitprint(9, verblevel, "Number of skipped profiles:   %8li  (%5.2f%%)\n",
-                             nskip, nskip*100.0/nlines);
-  transitprint(9, verblevel, "Number of evaluated profiles: %8li  (%5.2f%%)\n",
-                             neval, neval*100.0/nlines);
+  tr_output(TOUT_DEBUG, "Number of co-added lines:     %8li  (%5.2f%%)\n",
+    nadd,  nadd*100.0/nlines);
+  tr_output(TOUT_DEBUG, "Number of skipped profiles:   %8li  (%5.2f%%)\n",
+    nskip, nskip*100.0/nlines);
+  tr_output(TOUT_DEBUG, "Number of evaluated profiles: %8li  (%5.2f%%)\n",
+    neval, neval*100.0/nlines);
 
   /* Free allocated memory:                                                 */
   free(ktmp[0]);
@@ -637,8 +638,8 @@ interpolmolext(struct transit *tr, /* transit struct                        */
   itemp = binsearchapprox(gtemp, temp, 0, Ntemp);
   if (temp < gtemp[itemp])
     itemp--;
-  transitprint(30, verblevel, "Temperature: T[%i]=%.0f < %.2f < T[%.i]=%.0f\n",
-               itemp, gtemp[itemp], temp, itemp+1, gtemp[itemp+1]);
+  tr_output(TOUT_DEBUG, "Temperature: T[%i]=%.0f < %.2f < T[%.i]=%.0f\n",
+    itemp, gtemp[itemp], temp, itemp+1, gtemp[itemp+1]);
 
   for (i=0; i < Nwave; i++){
     /* Add contribution from each molecule:                                 */

--- a/transit/src/extinction.c
+++ b/transit/src/extinction.c
@@ -565,9 +565,9 @@ computemolext(struct transit *tr, /* transit struct                         */
     if (maxj > dnwn)
       maxj = dnwn;
 
-    tr_output(TOUT_DEBUG, "minj:%li  maxj:%li  subw:%li  offset:%li  "
-      "index1:%li\nf=np.array([",
-      minj, maxj, subw, offset, ofactor*minj - offset);
+    // tr_output(TOUT_DEBUG, "minj:%li  maxj:%li  subw:%li  offset:%li  "
+    //   "index1:%li\nf=np.array([",
+    //   minj, maxj, subw, offset, ofactor*minj - offset);
 
     /* Add the contribution from this line to the opacity spectrum:         */
     /* Adding in more complex but faster array indexing based on simpler

--- a/transit/src/makesample.c
+++ b/transit/src/makesample.c
@@ -104,8 +104,8 @@ makesample1(prop_samp *samp,       /* transit sampling    */
   }
 
   /* Progress report: print flag, spacing, and number of points from hint: */
-  transitprint(21, verblevel, "Flags: 0x%lx    hint.d: %g   hint.n: %li\n",
-               fl, ref->d, ref->n);
+  tr_output(TOUT_DEBUG, "Flags: 0x%lx    hint.d: %g   hint.n: %li\n",
+    fl, ref->d, ref->n);
 
   if (!dhint){
     /* If none of the ref exists then throw error: */
@@ -215,9 +215,9 @@ makesample(prop_samp *samp,  /* transit sampling                            */
   /* If hint unset, use reference:                                          */
   if(hint->i <= 0){
     samp->i = ref->i;
-    transitprint(4, verblevel,
-                 "Using ref sampling %g [cgs] for initial value of %s.\n",
-                 samp->i*samp->fct, TRH_NAME(fl));
+    tr_output(TOUT_INFO,
+      "Using ref sampling %g [cgs] for initial value of %s.\n",
+      samp->i*samp->fct, TRH_NAME(fl));
     res |= 0x1;  /* Turn on modification flag for return output             */
   }
   else
@@ -226,16 +226,16 @@ makesample(prop_samp *samp,  /* transit sampling                            */
   /* Set final value (if hint unset, use reference):                        */
   if (hint->f <= 0){
     samp->f = ref->f;
-    transitprint(4, verblevel,
-                 "Using ref sampling %g [cgs] for final value of %s.\n",
-                  samp->f*samp->fct, TRH_NAME(fl));
+    tr_output(TOUT_INFO,
+      "Using ref sampling %g [cgs] for final value of %s.\n",
+      samp->f*samp->fct, TRH_NAME(fl));
     res |= 0x2; /* Turn on modification flag for return output              */
   } else
     samp->f = hint->f;
 
   /* Print flag, spacing, and number of points from hint:                   */
-  transitprint(21, verblevel, "Flags: 0x%lx    hint.d: %g   hint.n: %li\n",
-                              fl, hint->d, hint->n);
+  tr_output(TOUT_DEBUG, "Flags: 0x%lx    hint.d: %g   hint.n: %li\n",
+    fl, hint->d, hint->n);
 
   /* If dhint has not been hinted then use ref's:                           */
   if(!dhint){
@@ -372,8 +372,8 @@ makewnsample(struct transit *tr){
       exit(EXIT_FAILURE);
     }
     rsamp.i = hsamp->i*hsamp->fct;
-    transitprint(1, verblevel, "wave i1: %.3f = %.2f * %.2f\n", rsamp.i,
-                 hsamp->i, hsamp->fct);
+    tr_output(TOUT_RESULT, "wave i1: %.3f = %.2f * %.2f\n", rsamp.i,
+      hsamp->i, hsamp->fct);
   }
   else if (wlsamp->f > 0){
     if (wlsamp->fct <= 0) {
@@ -437,11 +437,11 @@ makewnsample(struct transit *tr){
   res = makesample1(&tr->wns,  &rsamp, TRH_WN);
   /* Get the exact divisors of the oversampling factor:                     */
   tr->odivs = divisors(tr->owns.o, &tr->ndivs);
-  transitprint(20, verblevel, "There are %i divisors of the oversampling "
-                              "factor (%i):\n", tr->ndivs, tr->owns.o);
+  tr_output(TOUT_DEBUG, "There are %i divisors of the oversampling "
+    "factor (%i):\n", tr->ndivs, tr->owns.o);
   for (int i=0; i<tr->ndivs; i++)
-    transitprint(25, verblevel, "%5i", tr->odivs[i]);
-  transitprint(25, verblevel, "\n");
+    tr_output(TOUT_DEBUG, "%5i", tr->odivs[i]);
+  tr_output(TOUT_DEBUG, "\n");
 
   /* Set progress indicator if sampling was successful and return status:   */
   if(res >= 0)
@@ -501,7 +501,7 @@ makeradsample(struct transit *tr){
 
   /* Set interpolation function flag:                                       */
   flag = tr->interpflag;
-  transitprint(30, verblevel, "transit interpolation flag: %li.\n", flag);
+  tr_output(TOUT_DEBUG, "transit interpolation flag: %li.\n", flag);
 
   /* We need to set-up limit so that the hinted values are compatible
      with the atmosphere                                                    */
@@ -807,8 +807,8 @@ outsample(struct transit *tr){
       return 1;
     }
 
-  transitprint(1, verblevel, "Printing sampling information in '%s'.\n\n",
-               filename);
+  tr_output(TOUT_INFO, "Printing sampling information in '%s'.\n\n",
+    filename);
 
   /* Print each sample: */
   printsample(out, &tr->wns,  "Wavenumber",       TRF_NOVALUE);

--- a/transit/src/opacity.c
+++ b/transit/src/opacity.c
@@ -70,7 +70,7 @@ opacity(struct transit *tr){
 
   /* Check if the opacity file exists:                                      */
   int file_exists = fileexistopen(th->f_opa, NULL);
-  transitprint(10, verblevel, "Opacity-file exist status = %d\n", file_exists);
+  tr_output(TOUT_INFO, "Opacity-file exist status = %d\n", file_exists);
 
   /* Set the file name in the transit struct:                               */
   tr->f_opa = th->f_opa;
@@ -79,7 +79,7 @@ opacity(struct transit *tr){
   if (file_exists < -1 || file_exists == 0) {
 
     /* Calculate Voigt profiles:                                            */
-    transitprint(1, verblevel, "Calculating grid of Voigt profiles.\n");
+    tr_output(TOUT_INFO, "Calculating grid of Voigt profiles.\n");
     calcprofiles(tr);
 
     /* Set progress indicator and return success:                           */
@@ -101,11 +101,11 @@ opacity(struct transit *tr){
     }
 
     /* Calculate Voigt profiles:                                            */
-    transitprint(1, verblevel, "Calculating grid of Voigt profiles.\n");
+    tr_output(TOUT_INFO, "Calculating grid of Voigt profiles.\n");
     calcprofiles(tr);
 
     /* Calculate the grid of opacities:                                     */
-    transitprint(1, verblevel, "Calculating new grid of opacities: '%s'.\n",
+    tr_output(TOUT_INFO, "Calculating new grid of opacities: '%s'.\n",
                                tr->f_opa);
     calcopacity(tr, tr->fp_opa);
 
@@ -122,14 +122,14 @@ opacity(struct transit *tr){
   /* Implied: The opacity file exists:                                      */
   file_exists = fileexistopen(th->f_opa, &tr->fp_opa);
   tr->f_opa = th->f_opa;
-  transitprint(10, verblevel, "Opacity-file exist status = %d\n", file_exists);
+  tr_output(TOUT_INFO, "Opacity-file exist status = %d\n", file_exists);
 
   if (file_exists != 1) {
 
-    transitprint(1, verblevel, "Opening opacity file failed.\n");
+    tr_output(TOUT_WARN, "Opening opacity file failed.\n");
 
     /* Calculate Voigt profiles:                                            */
-    transitprint(1, verblevel, "Calculating grid of Voigt profiles.\n");
+    tr_output(TOUT_INFO, "Calculating grid of Voigt profiles.\n");
     calcprofiles(tr);
 
     /* Set progress indicator and return success:                           */
@@ -147,10 +147,10 @@ opacity(struct transit *tr){
     /* If reserving the hint segment was unsuccessful, give up:             */
     if (op.hintID == -1) {
 
-      transitprint(1, verblevel, "Could not get hint shared memory ID.\n");
+      tr_output(TOUT_WARN, "Could not get hint shared memory ID.\n");
 
       /* Read the grid of opacities from file:                              */
-      transitprint(1, verblevel, "Reading opacity file: '%s'.\n", tr->f_opa);
+      tr_output(TOUT_INFO, "Reading opacity file: '%s'.\n", tr->f_opa);
       readopacity(tr, tr->fp_opa);
 
       /* Set progress indicator and return success:                         */
@@ -164,10 +164,10 @@ opacity(struct transit *tr){
     /* If attaching was unsuccessful, give up.                              */
     if (op.hint == (struct opacityhint *) -1) {
 
-      transitprint(1, verblevel, "Could not attach to hint shared memory.\n");
+      tr_output(TOUT_WARN, "Could not attach to hint shared memory.\n");
 
       /* Read the grid of opacities from file:                              */
-      transitprint(1, verblevel, "Reading opacity file: '%s'.\n", tr->f_opa);
+      tr_output(TOUT_INFO, "Reading opacity file: '%s'.\n", tr->f_opa);
       readopacity(tr, tr->fp_opa);
 
       /* Set progress indicator and return success:                         */
@@ -187,15 +187,15 @@ opacity(struct transit *tr){
     if (op.hint->master_PID == getpid()) {
 
       /* Share the grid of opacities from file:                             */
-      transitprint(1, verblevel, "Sharing opacity file: '%s'.\n", tr->f_opa);
+      tr_output(TOUT_INFO, "Sharing opacity file: '%s'.\n", tr->f_opa);
 
       if (shareopacity(tr, tr->fp_opa) || mountopacity(tr)) {
 
-        transitprint(1, verblevel, "Shared memory sh/mt error. Aborting.\n");
+        tr_output(TOUT_WARN, "Shared memory sh/mt error. Aborting.\n");
         op.hint->status |= TSHM_ERROR;
 
         /* Read the grid of opacities from file:                            */
-        transitprint(1, verblevel, "Reading opacity file: '%s'.\n",
+        tr_output(TOUT_INFO, "Reading opacity file: '%s'.\n",
                                     tr->f_opa);
         readopacity(tr, tr->fp_opa);
       }
@@ -211,7 +211,7 @@ opacity(struct transit *tr){
       }
       while (buf2.shm_nattch != buf1.shm_nattch);
 
-      transitprint(1, verblevel, "Marking shared memory for removal.\n");
+      tr_output(TOUT_DEBUG, "Marking shared memory for removal.\n");
       shmctl(op.hintID, IPC_RMID, &buf1);
       shmctl(op.mainID, IPC_RMID, &buf2);
 
@@ -227,11 +227,10 @@ opacity(struct transit *tr){
         /* If there's an error with the shared memory, abort.               */
         if (op.hint->status & TSHM_ERROR) {
 
-          transitprint(1, verblevel, "Shared memory error. Aborting.\n");
+          tr_output(TOUT_WARN, "Shared memory error. Aborting.\n");
 
           /* Read the grid of opacities from file:                          */
-          transitprint(1, verblevel, "Reading opacity file: '%s'.\n",
-                                      tr->f_opa);
+          tr_output(TOUT_INFO, "Reading opacity file: '%s'.\n", tr->f_opa);
           readopacity(tr, tr->fp_opa);
 
           /* Set progress indicator and return success:                     */
@@ -244,11 +243,10 @@ opacity(struct transit *tr){
     /* If there's an error attaching or mounting the memory, abort.     */
     if (attachopacity(tr) || mountopacity(tr)) {
 
-      transitprint(1, verblevel, "Shared memory att/mt error. Aborting.\n");
+      tr_output(TOUT_WARN, "Shared memory att/mt error. Aborting.\n");
 
       /* Read the grid of opacities from file:                          */
-      transitprint(1, verblevel, "Reading opacity file: '%s'.\n",
-                                  tr->f_opa);
+      tr_output(TOUT_INFO, "Reading opacity file: '%s'.\n", tr->f_opa);
       readopacity(tr, tr->fp_opa);
     }
   }
@@ -257,7 +255,7 @@ opacity(struct transit *tr){
   else {
 
     /* Read the grid of opacities from file:                                */
-    transitprint(1, verblevel, "Reading opacity file: '%s'.\n", tr->f_opa);
+    tr_output(TOUT_INFO, "Reading opacity file: '%s'.\n", tr->f_opa);
     readopacity(tr, tr->fp_opa);
   }
 
@@ -304,7 +302,7 @@ calcprofiles(struct transit *tr){
     op->profile[i] = op->profile[0] + i*nLor;
   }
   profile = op->profile;
-  transitprint(10, verblevel, "Number of Voigt profiles: %d.\n", nDop*nLor);
+  tr_output(TOUT_RESULT, "Number of Voigt profiles: %d.\n", nDop*nLor);
 
   t0 = timestart(tv, "Begin Voigt profiles calculation.");
   /* Evaluate the profiles for the array of widths:                         */
@@ -321,9 +319,8 @@ calcprofiles(struct transit *tr){
                              tr->wns.d/tr->owns.o, op->aDop[i], op->aLor[j],
                              timesalpha, tr->owns.n);
       }
-      transitprint(25, verblevel, "Profile[%2d][%2d] size = %4li  (D=%.3g, "
-                                  "L=%.3g).\n", i, j, 2*op->profsize[i][j]+1,
-                                   op->aDop[i], op->aLor[j]);
+      tr_output(TOUT_DEBUG, "Profile[%2d][%2d] size = %4li  (D=%.3g, "
+        "L=%.3g).\n", i, j, 2*op->profsize[i][j]+1, op->aDop[i], op->aLor[j]);
     }
   }
   t0 = timecheck(verblevel, 0, 0, "End Voigt-profile calculation.", tv, t0);
@@ -367,7 +364,7 @@ calcopacity(struct transit *tr,
       "TLI temperature (%.1f K).\n", op->temp[Ntemp-1], li->tmax);
     exit(EXIT_FAILURE);
   }
-  transitprint(1, verblevel, "There are %li temperature samples.\n", Ntemp);
+  tr_output(TOUT_RESULT, "There are %li temperature samples.\n", Ntemp);
 
   /* Evaluate the partition at these temperatures:                          */
   op->ziso    = (PREC_ATM **)calloc(iso->n_i,       sizeof(PREC_ATM *));
@@ -397,20 +394,20 @@ calcopacity(struct transit *tr,
   op->press = (PREC_RES *)calloc(Nlayer, sizeof(PREC_RES));
   for (i=0; i<Nlayer; i++)
     op->press[i] = tr->atm.p[i]*tr->atm.pfct;
-  transitprint(1, verblevel, "There are %li radius samples.\n", Nlayer);
+  tr_output(TOUT_RESULT, "There are %li radius samples.\n", Nlayer);
 
   /* Make molecules array from transit:                                     */
   Nmol = op->Nmol = tr->ds.iso->nmol;
   op->molID = (int *)calloc(Nmol, sizeof(int));
-  transitprint(1, verblevel, "There are %li molecules with line "
-                             "transitions.\n", Nmol);
+  tr_output(TOUT_RESULT, "There are %li molecules with line "
+    "transitions.\n", Nmol);
   for (i=0, j=0; i<iso->n_i; i++){
     /* If this molecule is not yet in molID array, add it's universal ID:   */
     if (valueinarray(op->molID, mol->ID[iso->imol[i]], j) < 0){
       op->molID[j++] = mol->ID[iso->imol[i]];
-      transitprint(10, verblevel, "Isotope's (%d) molecule ID: %d (%s) "
-                   "added at position %d.\n", i, op->molID[j-1],
-                   mol->name[iso->imol[i]], j-1);
+      tr_output(TOUT_DEBUG, "Isotope's (%d) molecule ID: %d (%s) "
+        "added at position %d.\n", i, op->molID[j-1],
+        mol->name[iso->imol[i]], j-1);
     }
   }
 
@@ -419,7 +416,7 @@ calcopacity(struct transit *tr,
   op->wns = (PREC_RES *)calloc(Nwave, sizeof(PREC_RES));
   for (i=0; i<Nwave; i++)
     op->wns[i] = tr->wns.v[i];
-  transitprint(1, verblevel, "There are %li wavenumber samples.\n", Nwave);
+  tr_output(TOUT_RESULT, "There are %li wavenumber samples.\n", Nwave);
 
   /* Allocate opacity array:                                                */
   if (fp != NULL){
@@ -435,12 +432,12 @@ calcopacity(struct transit *tr,
     }
 
     if (!op->o[0][0][0])
-      transitprint(1, verblevel, "Allocation fail.\n");
+      tr_output(TOUT_ERROR, "Allocation fail.\n");
 
     /* Compute extinction:                                                  */
     for (r=0;   r<Nlayer; r++){  /* For each layer:                         */
-      transitprint(3, verblevel, "\nOpacity Grid at layer %03d/%03ld.\n",
-                                 r+1, Nlayer);
+      tr_output(TOUT_DEBUG, "\nOpacity Grid at layer %03d/%03ld.\n",
+        r+1, Nlayer);
       for (t=0; t<Ntemp;  t++){  /* For each temperature:                   */
         /* Get density and partition-function arrays:                       */
         for (j=0; j < mol->nmol; j++)
@@ -476,7 +473,7 @@ calcopacity(struct transit *tr,
 
     fclose(fp);
   }
-  transitprint(2, verblevel, "Done.\n");
+  tr_output(TOUT_RESULT, "Done.\n");
   return 0;
 }
 
@@ -494,12 +491,12 @@ readopacity(struct transit *tr,  /* transit struct                          */
   fread(&op->Ntemp,  sizeof(long), 1, fp);
   fread(&op->Nlayer, sizeof(long), 1, fp);
   fread(&op->Nwave,  sizeof(long), 1, fp);
-  transitprint(1, verblevel, "Opacity grid size: Nmolecules    = %5li\n"
-                             "                   Ntemperatures = %5li\n"
-                             "                   Nlayers       = %5li\n"
-                             "                   Nwavenumbers  = %5li\n",
-                             op->Nmol, op->Ntemp, op->Nlayer, op->Nwave);
-  transitprint(20, verblevel, "ftell = %li\n", ftell(fp));
+  tr_output(TOUT_INFO, "Opacity grid size: Nmolecules    = %5li\n"
+    "                   Ntemperatures = %5li\n"
+    "                   Nlayers       = %5li\n"
+    "                   Nwavenumbers  = %5li\n",
+    op->Nmol, op->Ntemp, op->Nlayer, op->Nwave);
+  tr_output(TOUT_DEBUG, "ftell = %li\n", ftell(fp));
 
   /* Allocate and read arrays:                                              */
   op->molID = (int      *)calloc(op->Nmol,   sizeof(int));
@@ -512,28 +509,28 @@ readopacity(struct transit *tr,  /* transit struct                          */
   fread(op->wns,   sizeof(PREC_RES), op->Nwave,  fp);
 
   /* DEBUGGING: Print temperature array                                     */
-  transitprint(10, verblevel, "Molecule IDs = [");
+  tr_output(TOUT_DEBUG, "Molecule IDs = [");
   for (i=0; i < op->Nmol; i++)
-    transitprint(10, verblevel, "%3d, ", op->molID[i]);
-  transitprint(10, verblevel, "\b\b]\n\n");
+    tr_output(TOUT_DEBUG, "%3d, ", op->molID[i]);
+  tr_output(TOUT_DEBUG, "\b\b]\n\n");
 
-  transitprint(10, verblevel, "Temperatures (K)  =  [");
+  tr_output(TOUT_DEBUG, "Temperatures (K)  =  [");
   for (i=0; i < op->Ntemp; i++)
-    transitprint(10, verblevel, "%6d, ", (int)op->temp[i]);
-  transitprint(10, verblevel, "\b\b] \n\n");
+    tr_output(TOUT_DEBUG, "%6d, ", (int)op->temp[i]);
+  tr_output(TOUT_DEBUG, "\b\b] \n\n");
 
-  transitprint(10, verblevel, "Pressures (bar) = [ ");
+  tr_output(TOUT_DEBUG, "Pressures (bar) = [ ");
   for (i=0; i < op->Nlayer; i++)
-    transitprint(10, verblevel, "%.2e, ", 1e-6*op->press[i]);
-  transitprint(10, verblevel, "\b\b] \n\n");
+    tr_output(TOUT_DEBUG, "%.2e, ", 1e-6*op->press[i]);
+  tr_output(TOUT_DEBUG, "\b\b] \n\n");
 
-  transitprint(10, verblevel, "Wavenumber (cm-1) = [");
+  tr_output(TOUT_DEBUG, "Wavenumber (cm-1) = [");
   for (i=0; i < 4; i++)
-    transitprint(10, verblevel, "%7.2f, ", op->wns[i]);
-  transitprint(10, verblevel, "..., ");
+    tr_output(TOUT_DEBUG, "%7.2f, ", op->wns[i]);
+  tr_output(TOUT_DEBUG, "..., ");
   for (i=op->Nwave-4; i < op->Nwave; i++)
-    transitprint(10, verblevel, "%7.2f, ", op->wns[i]);
-  transitprint(10, verblevel, "\b\b]\n\n");
+    tr_output(TOUT_DEBUG, "%7.2f, ", op->wns[i]);
+  tr_output(TOUT_DEBUG, "\b\b]\n\n");
 
   /* Allocate and read the opacity grid:                                    */
   op->o      = (PREC_RES ****)       calloc(op->Nlayer, sizeof(PREC_RES ***));
@@ -569,12 +566,12 @@ shareopacity(struct transit *tr, /* transit struct                          */
   fread(&op->Ntemp,  sizeof(long), 1, fp);
   fread(&op->Nlayer, sizeof(long), 1, fp);
   fread(&op->Nwave,  sizeof(long), 1, fp);
-  transitprint(1, verblevel, "Opacity grid size: Nmolecules    = %5li\n"
-                             "                   Ntemperatures = %5li\n"
-                             "                   Nlayers       = %5li\n"
-                             "                   Nwavenumbers  = %5li\n",
-                             op->Nmol, op->Ntemp, op->Nlayer, op->Nwave);
-  transitprint(20, verblevel, "ftell = %li\n", ftell(fp));
+  tr_output(TOUT_INFO, "Opacity grid size: Nmolecules    = %5li\n"
+    "                   Ntemperatures = %5li\n"
+    "                   Nlayers       = %5li\n"
+    "                   Nwavenumbers  = %5li\n",
+    op->Nmol, op->Ntemp, op->Nlayer, op->Nwave);
+  tr_output(TOUT_DEBUG, "ftell = %li\n", ftell(fp));
 
   /* Copy dimensional data into the shared hint struct:                     */
   oh->Nwave = op->Nwave;
@@ -632,7 +629,6 @@ attachopacity(struct transit *tr){ /* transit struct                        */
   /* If allocation failed, abort:                                           */
   if (op->mainID == -1) {
     tr_output(TOUT_WARN, "Failed to allocate main shared memory.\n");
-    transitprint(1, verblevel, "Attachment failed. shmget() returned -1.\n");
     return 1;
   }
 
@@ -641,7 +637,6 @@ attachopacity(struct transit *tr){ /* transit struct                        */
 
   if (op->mainaddr == (void *) -1) {
     tr_output(TOUT_WARN, "Failed to attach to main shared memory.\n");
-    transitprint(1, verblevel, "Attachment failed. shmat() returned -1.\n");
     return 1;
   }
 

--- a/transit/src/readatm.c
+++ b/transit/src/readatm.c
@@ -595,12 +595,10 @@ readatmfile(FILE *fp,                /* Atmospheric file                    */
     /* Calculate mean molecular mass and check whether abundances add up
        to one (within allowq threshold):                                    */
     sumq = checkaddmm(at->mm+r, r, molec, mol, at->n_aiso, at->mass);
-    if(fabs(sumq-1.0) > allowq) {
-      tr_output(TOUT_ERROR,
+    if(fabs(sumq-1.0) > allowq)
+      tr_output(TOUT_WARN,
         "In radius %i (%g km), abundances don't add "
         "up to 1.0: %.9g\n", r, at->rads.v[r], sumq);
-      exit(EXIT_FAILURE);
-    }
 
     /* Calculate densities using ideal gas law:                             */
     if (r>=0){

--- a/transit/src/readlineinfo.c
+++ b/transit/src/readlineinfo.c
@@ -80,14 +80,14 @@ datafileBS(FILE *fp,            /* File pointer                             */
             hi=nfields-1,  /* Starting point of binary search               */
             loc;           /* Current location of closest value             */
 
-  transitDEBUG(30, verblevel, "BS: Start looking from %li in %li fields "
-                              "for %f\n", offs, nfields, target);
+  tr_output(TOUT_DEBUG, "BS: Start looking from %li in %li fields "
+    "for %f\n", offs, nfields, target);
   /* Binary search:                                                         */
   do{
     loc = (hi+lo)/2;                           /* Mid record's index        */
     fseek(fp, offs+reclength*loc, SEEK_SET);   /* Move pointer              */
     fread(&temp, sizeof(PREC_LNDATA), 1, fp);  /* Read value                */
-    transitDEBUG(30, verblevel, "BS: found wl %.8f microns at position %li\n",
+    tr_output(TOUT_DEBUG, "BS: found wl %.8f microns at position %li\n",
                                 temp*tli_to_microns, loc);
     /* Re-set lower or higher boundary:                                     */
     if(target > temp)
@@ -225,15 +225,14 @@ readtli_bin(FILE *fp,
     li->isov[correliso].z = (double *)calloc((correliso+nDBiso)*nT,
                                              sizeof(double));
 
-    transitDEBUG(21, verblevel, "So far, cumIsotopes: %i, at databases: %i, "
-                 "position %li.\n", correliso+nDBiso, i, ftell(fp));
+    tr_output(TOUT_DEBUG, "So far, cumIsotopes: %i, at databases: %i, "
+      "position %li.\n", correliso+nDBiso, i, ftell(fp));
 
     /* Display database general info:                                       */
-    transitDEBUG(23, verblevel, "DB %i: '%s' has %i (%i) temperatures, "
-                 "%i (%i) isotopes, and starts at cumulative isotope %i.\n",
-                 iso->isof[correliso].d, iso->db[i].n,
-                 li->db[i].t, nT,
-                 iso->db[i].i, nDBiso, iso->db[i].s);
+    tr_output(TOUT_DEBUG, "DB %i: '%s' has %i (%i) temperatures, "
+      "%i (%i) isotopes, and starts at cumulative isotope %i.\n",
+      iso->isof[correliso].d, iso->db[i].n,
+      li->db[i].t, nT, iso->db[i].i, nDBiso, iso->db[i].s);
 
 
     /* Read the isotopes from this data base:                               */
@@ -357,10 +356,10 @@ checkrange(struct transit *tr,   /* General parameters and  hints           */
   wlmin = 1.0/(tsamp->f*tsamp->fct);
   wlmax = 1.0/(tsamp->i*tsamp->fct);
 
-  transitDEBUG(10, verblevel,
-               "Transit initial and final wavelengths are %6g and %6g cm.\n"
-               "The database max and min wavelengths are  %6g and %6g cm.\n",
-               wlmin, wlmax, dbini, dbfin);
+  tr_output(TOUT_DEBUG,
+    "Transit initial and final wavelengths are %6g and %6g cm.\n"
+    "The database max and min wavelengths are  %6g and %6g cm.\n",
+    wlmin, wlmax, dbini, dbfin);
 
   /* Check that it is not below the minimum value:                          */
   if(dbini > wlmax){
@@ -791,8 +790,7 @@ int main(int argc, char **argv){
     tr_output(TOUT_ERROR, "Error code: %i.\n", i);
     exit(EXIT_FAILURE);
   }
-  transitDEBUG(20, verblevel, "range: %.10g to %.10g.\n",
-               tr.ds.li->wi, tr.ds.li->wf);
+  tr_output(TOUT_DEBUG, "range: %.10g to %.10g.\n", tr.ds.li->wi, tr.ds.li->wf);
   li = tr.ds.li;
   ltgf = tr.ds->lt.gf;
   ltwl = tr.ds->lt.wl;

--- a/transit/src/slantpath.c
+++ b/transit/src/slantpath.c
@@ -88,8 +88,9 @@ totaltau1(PREC_RES b,    /* Impact parameter                                */
     return 0;  /* If it is the outmost layer                                */
   /* If some other error occurred:                                          */
   else if(rs < 0){
-    transiterror(TERR_CRITICAL, "Closest approach (%g) is larger than the "
-                 "top layer of the atmosphere (%g).\n", r0, rad[nrad-1]);
+    tr_output(TOUT_ERROR, "Closest approach (%g) is larger than the "
+      "top layer of the atmosphere (%g).\n", r0, rad[nrad-1]);
+    exit(EXIT_FAILURE);
   }
 
   /* Move extinction and radius pointers to the rs-th element:              */
@@ -181,17 +182,20 @@ totaltau2(PREC_RES b,      /* Impact parameter                              */
   /* Auxiliary variables for Simson integration:                            */
   double *hsum, *hratio, *hfactor, *h;
 
-  transiterror(TERR_CRITICAL, "This routine has not been implemented yet.\n");
+  tr_output(TOUT_ERROR, "This routine has not been implemented yet.\n");
+  exit(EXIT_FAILURE);
 
   /* Look for closest approach radius:                                      */
   while(1){
     r0 = b/lineinterp(r0a, rad, refr, nrad);
     if(r0==r0a)
       break;
-    if(i++ > maxiterations)
-      transiterror(TERR_CRITICAL, "Maximum iterations (%i) reached while "
-                   "looking for r0. Convergence not reached (%.6g!=%.6g).\n",
-                   maxiterations, r0, r0a);
+    if(i++ > maxiterations) {
+      tr_output(TOUT_ERROR, "Maximum iterations (%i) reached while "
+        "looking for r0. Convergence not reached (%.6g!=%.6g).\n",
+        maxiterations, r0, r0a);
+      exit(EXIT_FAILURE);
+    }
     r0a = r0;
   }
 
@@ -202,10 +206,12 @@ totaltau2(PREC_RES b,      /* Impact parameter                              */
     return 0;
 
   /* If some other error occurred:                                          */
-  else if(rs<0)
-    transiterror(TERR_CRITICAL,
-                 "Closest approach value(%g) is outside sampled radius "
-                 "range(%g - %g).\n", r0, rad[0], rad[nrad-1]);
+  else if(rs<0) {
+    tr_output(TOUT_ERROR,
+      "Closest approach value(%g) is outside sampled radius "
+      "range(%g - %g).\n", r0, rad[0], rad[nrad-1]);
+    exit(EXIT_FAILURE);
+  }
   /* Move pointer to rs-th element:                                         */
   rs++;
   /* FINDME: This will break                                                */
@@ -302,9 +308,10 @@ transittau(struct transit *tr,
     return totaltau2(b, rad,  refr, ex, nrad);
     break;
   default:
-    transiterror(TERR_CRITICAL,
-                 "slantpath:: totaltau:: Level %i of detail has not been "
-                 "implemented to compute optical depth.\n", tr->taulevel);
+    tr_output(TOUT_ERROR,
+      "slantpath:: totaltau:: Level %i of detail has not been "
+      "implemented to compute optical depth.\n", tr->taulevel);
+    exit(EXIT_FAILURE);
     return 0;
   }
 }
@@ -349,15 +356,18 @@ modulation(struct transit *tr){
     if (out[w] < 0){
       switch(-(int)out[w]){
       case 1:
-        if(tr->modlevel == -1)
-          transiterror(TERR_SERIOUS, "Optical depth didn't reach limiting "
-                       "%g at wavenumber %g cm-1 (only reached %g).  Cannot "
-                       "use critical radius technique (-1).\n", tau->toomuch,
-                       tau->t[w][tau->last[w]], wn->v[w]*wn->fct);
+        if(tr->modlevel == -1) {
+          tr_output(TOUT_ERROR, "Optical depth didn't reach limiting "
+            "%g at wavenumber %g cm-1 (only reached %g).  Cannot "
+            "use critical radius technique (-1).\n", tau->toomuch,
+            tau->t[w][tau->last[w]], wn->v[w]*wn->fct);
+          exit(EXIT_FAILURE);
+        }
       default:
-        transiterror(TERR_SERIOUS, "There was a problem while calculating "
-                     "modulation at wavenumber %g cm-1. Error code %i.\n",
-                     wn->v[w]*wn->fct, (int)out[w]);
+        tr_output(TOUT_ERROR, "There was a problem while calculating "
+          "modulation at wavenumber %g cm-1. Error code %i.\n",
+          wn->v[w]*wn->fct, (int)out[w]);
+        exit(EXIT_FAILURE);
         break;
       }
       exit(EXIT_FAILURE);
@@ -429,9 +439,11 @@ modulation1(PREC_RES *tau,        /* Optical depth array                    */
   /* Increment last to represent the number of elements, check that we
      have enough:                                                           */
   last++;
-  if(last < 3)
-    transiterror(TERR_CRITICAL, "Condition failed, less than 3 items "
-                                "(only %i) for radial integration.\n", last);
+  if(last < 3) {
+    tr_output(TOUT_ERROR, "Condition failed, less than 3 items "
+      "(only %i) for radial integration.\n", last);
+    exit(EXIT_FAILURE);
+  }
 
   /* Integrate along radius:                                                */
   hsum    = calloc(last/2, sizeof(double));
@@ -532,9 +544,10 @@ modulationperwn(struct transit *tr,  /* Transit structure                   */
     return modulationm1(tau, last, toomuch, ip, sg);
     break;
   default:
-    transiterror(TERR_CRITICAL, "slantpath:: modulationperwn:: Level %i of "
-                 "detail has not been implemented to compute modulation.\n",
-                 tr->modlevel);
+    tr_output(TOUT_ERROR, "slantpath:: modulationperwn:: Level %i of "
+      "detail has not been implemented to compute modulation.\n",
+      tr->modlevel);
+    exit(EXIT_FAILURE);
     return 0;
   }
 }

--- a/transit/src/slantpath.c
+++ b/transit/src/slantpath.c
@@ -345,7 +345,7 @@ modulation(struct transit *tr){
   setgeom(sg, HUGE_VAL, &tr->pi);
 
   /* Integrate for each wavelength:                                         */
-  transitprint(1, verblevel, "Integrating over wavelength.\n");
+  tr_output(TOUT_RESULT, "Integrating over wavelength.\n");
 
   int nextw = wn->n/10;
 
@@ -376,10 +376,11 @@ modulation(struct transit *tr){
     /* Print to screen the progress status:                                 */
     if(w==nextw){
       nextw += wn->n/10;
-      transitprint(2, verblevel, "%i%% ", (10*(int)(10*w/wn->n+0.9999999999)));
+      tr_output(TOUT_DEBUG, "%i%% ", (10*(int)(10*w/wn->n+0.9999999999)));
     }
   }
-  transitprint(1, verblevel, "\nDone.\n");
+  tr_output(TOUT_DEBUG, "\n");
+  tr_output(TOUT_RESULT, "Done.\n");
 
   /* Set progress indicator, and print output:                              */
   tr->pi |= TRPI_MODULATION;
@@ -566,9 +567,9 @@ printmod(struct transit *tr){
   if(tr->f_outmod && tr->f_outmod[0] != '-')
     outf = fopen(tr->f_outmod, "w");
 
-  transitprint(1, verblevel,
-               "\nPrinting in-transit/out-transit modulation in '%s'.\n",
-               tr->f_outmod?tr->f_outmod:"standard output");
+  tr_output(TOUT_INFO,
+    "\nPrinting in-transit/out-transit modulation in '%s'.\n",
+    tr->f_outmod?tr->f_outmod:"standard output");
 
   /* Print: */
   char wlu[20], /* Wavelength units name */

--- a/transit/src/tau.c
+++ b/transit/src/tau.c
@@ -314,8 +314,8 @@ tau(struct transit *tr){
         }
         break;  /* Exit height loop when the optical depth reached toomuch  */
       }
-      transitDEBUG(22, verblevel, "Tau(lambda %li=%9.07g, r=%9.4g) : %g "
-          "(toomuch: %g)\n", wi, wn->v[wi], r[ri], tau_wn[ri], tau->toomuch);
+      tr_output(TOUT_DEBUG, "Tau(lambda %li=%9.07g, r=%9.4g) : %g "
+        "(toomuch: %g)\n", wi, wn->v[wi], r[ri], tau_wn[ri], tau->toomuch);
     }
 
     /* Write total, cloud, and scattering extinction to file if requested:  */

--- a/transit/src/tau.c
+++ b/transit/src/tau.c
@@ -208,7 +208,7 @@ tau(struct transit *tr){
 
   /* Compute extinction at the outermost layer:                             */
   if(!comp[rnn-1]){
-    transitprint(1, verblevel, "Computing extinction at outermost layer.\n");
+    tr_output(TOUT_INFO, "Computing extinction at outermost layer.\n");
     if (tr->fp_opa != NULL)
       rn = interpolmolext(tr, rnn-1, ex->e);
     else if (tr->f_line != NULL){
@@ -240,14 +240,14 @@ tau(struct transit *tr){
               "# e_s [wn][rad]; wn[0]=min(wn), row[0]=bottom (max(p))\n");
   }
 
-  transitprint(1, verblevel, "Calculating optical depth at various radii:\n");
+  tr_output(TOUT_INFO, "Calculating optical depth at various radii:\n");
   /* For each wavenumber:                                                   */
   for(wi=0; wi<wnn; wi++){
     tau_wn = tau->t[wi];
 
     /* Print output every 10% progress:                                     */
     if(wi > wnextout){
-      transitprint(12, verblevel, "%i%%\n", (int)(100*(float)wi/wnn+0.5));
+      tr_output(TOUT_DEBUG, "%i%%\n", (int)(100*(float)wi/wnn+0.5));
       wnextout += (long)(wnn/10.0);
     }
 
@@ -268,14 +268,14 @@ tau(struct transit *tr){
         /* FINDME: What if the ray ends up going through a lower layer because
            of the refraction? */
         if(ri)
-          transitprint(30, verblevel, "Last Tau (height=%9.4g, wn=%9.4g): "
+          tr_output(TOUT_DEBUG, "Last Tau (height=%9.4g, wn=%9.4g): "
                                "%10.4g.\n", h[ri-1], wn->v[wi], tau_wn[ri-1]);
         /* While the extinction at a radius bigger than the impact
            parameter is not computed, go for it: */
         do{
           if(!comp[--lastr]){
             /* Compute extinction at given radius:                          */
-            transitprint(15, verblevel, "Radius %i: %.9g cm ... \n",
+            tr_output(TOUT_DEBUG, "Radius %i: %.9g cm ... \n",
                                         lastr+1, r[lastr]*rfct);
             if (tr->fp_opa != NULL)
               rn = interpolmolext(tr, lastr, ex->e);
@@ -326,13 +326,13 @@ tau(struct transit *tr){
     }
 
     if(ri==nh){
-      transitprint(1, verblevel, "WARNING: At wavenumber %g cm-1, tau reached "
-                   "the bottom of the atmosphere with tau: %g (tau max: %g).\n",
-                   wn->v[wi], tau_wn[ri-1], tau->toomuch);
+      tr_output(TOUT_WARN, "At wavenumber %g cm-1, tau reached "
+        "the bottom of the atmosphere with tau: %g (tau max: %g).\n",
+        wn->v[wi], tau_wn[ri-1], tau->toomuch);
       tau->last[wi] = ri-1;
     }
   }
-  transitprint(1, verblevel, "Done.\n");
+  tr_output(TOUT_INFO, "Done.\n");
 
   /* Save various files if requested in the config file:                 */
 
@@ -575,8 +575,8 @@ detailout(prop_samp *wn,         /* transit's wavenumber array              */
       det->file);
     exit(EXIT_FAILURE);
   }
-  transitprint(1, verblevel, "\nPrinting in '%s'. Fine detail of %s at "
-                             "selected wavenumbers.\n", det->file, det->name);
+  tr_output(TOUT_INFO, "\nPrinting in '%s'. Fine detail of %s at "
+    "selected wavenumbers.\n", det->file, det->name);
 
   fprintf(out, "#Radius-w=>    ");
   /* Binary search to find the index for the requested wavenumbers:         */
@@ -653,8 +653,8 @@ printtoomuch(char *file,            /* Filename to save the info            */
     tr_output(TOUT_WARN, "Cannot open '%s' for writing depth where the "
       "optical depth reached toomuch.\n", file);
 
-  transitprint(20, verblevel, "\nPrinting in '%s' the depth where the "
-                   "optical depth got larger than %g.\n", file, tau->toomuch);
+  tr_output(TOUT_INFO, "\nPrinting in '%s' the depth where the "
+    "optical depth got larger than %g.\n", file, tau->toomuch);
 
   /* Print header:                                                          */
   fprintf(out,

--- a/transit/src/transit.c
+++ b/transit/src/transit.c
@@ -86,10 +86,6 @@ void transit_init(int argc, char **argv){
   /* Presentation:                                                          */
   printintro();
 
-  /* No program warnings if verblevel is 0 or 1:                            */
-  if(verblevel<2)
-    transit_nowarn = 1;
-
   /* Make wavenumber binning:                                               */
   fw(makewnsample, <0, &transit);
   t0 = timecheck(verblevel, itr,  1, "makewnsample", tv, t0);

--- a/transit/src/transit.c
+++ b/transit/src/transit.c
@@ -79,7 +79,7 @@ void transit_init(int argc, char **argv){
   fw(processparameters, !=0, argc, argv, &transit);
   t0 = timecheck(verblevel, itr,  0, "processparameters", tv, t0);
 
-  transitprint(1, verblevel, "verblevel: %d\n", verblevel);
+  tr_output(TOUT_INFO, "verblevel: %d\n", verblevel);
 
   /* Accept all general hints:                                              */
   fw(acceptgenhints, !=0, &transit);
@@ -94,10 +94,10 @@ void transit_init(int argc, char **argv){
   fw(makewnsample, <0, &transit);
   t0 = timecheck(verblevel, itr,  1, "makewnsample", tv, t0);
   if(fw_status>0)
-    transitprint(7, verblevel,
-                 "makewnsample() modified some of the hinted "
-                 "parameters according to returned flag: 0x%lx.\n",
-                 fw_status);
+    tr_output(TOUT_INFO,
+      "makewnsample() modified some of the hinted "
+      "parameters according to returned flag: 0x%lx.\n",
+      fw_status);
 
   /* Read Atmosphere information:                                           */
   fw(getatm, !=0, &transit);
@@ -111,8 +111,8 @@ void transit_init(int argc, char **argv){
   fw(makeradsample, <0, &transit);
   t0 = timecheck(verblevel, itr,  4, "makeradsample", tv, t0);
   if(fw_status>0)
-    transitprint(7, verblevel, "makeradsample() modified some of the hinted "
-                               "parameters. Flag: 0x%lx.\n", fw_status);
+    tr_output(TOUT_INFO, "makeradsample() modified some of the hinted "
+      "parameters. Flag: 0x%lx.\n", fw_status);
 
   /* Calculate opacity grid:                                                */
   fw(opacity, <0, &transit);
@@ -176,8 +176,8 @@ void do_transit(double * transit_out){
     fw(makeipsample, <0, &transit);
     t0 = timecheck(verblevel, itr,  6, "makeipsample", tv, t0);
     if(fw_status>0)
-      transitprint(7, verblevel, "makeipsample() modified some of the hinted "
-                                 "parameters. Flag: 0x%lx.\n", fw_status);
+      tr_output(TOUT_INFO, "makeipsample() modified some of the hinted "
+        "parameters. Flag: 0x%lx.\n", fw_status);
 
     /* Interpolate the cross section:                                       */
     fw(interpcs, !=0, &transit);
@@ -196,7 +196,7 @@ void do_transit(double * transit_out){
 
     /* Calculate optical depth for eclipse:                                 */
     if(strcmp(transit.sol->name, "eclipse") == 0){
-      transitprint(1, verblevel, "\nCalculating eclipse:\n");
+      tr_output(TOUT_INFO, "\nCalculating eclipse:\n");
 
       fw(tau, !=0, &transit);
       t0 = timecheck(verblevel, itr, 12, "tau eclipse", tv, t0);
@@ -221,7 +221,7 @@ void do_transit(double * transit_out){
 
     /* Calculate optical depth for transit:                                 */
     else if (strcmp(transit.sol->name, "transit") == 0){
-      transitprint(1, verblevel, "\nCalculating transit:\n");
+      tr_output(TOUT_INFO, "\nCalculating transit:\n");
       fw(tau, !=0, &transit);
       t0 = timecheck(verblevel, itr, 12, "tau transit", tv, t0);
 
@@ -243,7 +243,8 @@ void do_transit(double * transit_out){
     freemem_outputray( transit.ds.out, &transit.pi);
 
     t0 = timecheck(verblevel, itr, 14, "THE END", tv, t0);
-    transitprint(1, verblevel, "----------------------------\n");
+    tr_output(TOUT_INFO,
+      "--------------------------------------------------\n");
     itr++;
   }
 }

--- a/transit/src/transitstd.c
+++ b/transit/src/transitstd.c
@@ -500,7 +500,7 @@ timestart(struct timeval tv,  /* timeval structure                          */
   gettimeofday(&tv, NULL);
   /* Calculate time in seconds:                                             */
   double sec = tv.tv_sec + 1e-6*tv.tv_usec;
-  transitprint(1, verblevel, "%s\n", str);
+  tr_output(TOUT_INFO, "%s\n", str);
   return sec;
 }
 
@@ -518,7 +518,7 @@ timecheck(int verblevel,      /* Verbosity level         */
   /* Calculate time in seconds: */
   double sec = tv.tv_sec + 1e-6*tv.tv_usec;
   /* Print time stamp:          */
-  transitprint(1, verblevel, "Check point: %02li - %02li %s:  dt = %.4f "
-                             "sec.\n\n", iter, index, str, sec-t0);
+  tr_output(TOUT_RESULT, "Check point: %02li - %02li %s:  dt = %.4f "
+    "sec.\n\n", iter, index, str, sec-t0);
   return sec;
 }

--- a/transit/src/transitstd.c
+++ b/transit/src/transitstd.c
@@ -66,6 +66,56 @@ inline void transitdot(int thislevel,
     fwrite(".", 1, 1, stderr);
 }
 
+void
+tr_output_fcn (int level,
+               const char *file,
+               const long line,
+               const char *str,
+               ...) {
+
+  va_list format;
+  va_start(format, str);
+  tr_output_vfcn(level, file, line, str, format);
+  va_end(format);
+}
+
+void
+tr_output_vfcn (int level,
+                const char *file,
+                const long line,
+                const char *str,
+                va_list format) {
+
+  // First decide to where the 
+  FILE *output = ((level & TOUT_VERBMASK) == TOUT_ERROR) ? stderr : stdout;
+
+  // Header message?
+  if (level & TOUT_BANNER)
+    fprintf(output, "\n--------------------------------------------------\n");
+
+  if ((level & TOUT_VERBMASK) == TOUT_ERROR)
+    fprintf(output, "Transit ERROR :: (%s, line %lu)\n", file, line);
+
+  else if ((level & TOUT_VERBMASK) == TOUT_WARN)
+    fprintf(output, "Transit WARNING :: (%s, line %lu)\n", file, line);
+
+  else if ((level & TOUT_LOCATE) && ((level & TOUT_VERBMASK) == TOUT_INFO))
+    fprintf(output, "Transit INFO :: (%s, line %lu)\n", file, line);
+
+  else if ((level & TOUT_LOCATE) && ((level & TOUT_VERBMASK) == TOUT_RESULT))
+    fprintf(output, "Transit RESULT :: (%s, line %lu)\n", file, line);
+
+  else if ((level & TOUT_LOCATE) && ((level & TOUT_VERBMASK) == TOUT_DEBUG))
+    fprintf(output, "Transit DEBUG :: (%s, line %lu)\n", file, line);
+
+  // Message
+  vfprintf(output, str, format);
+
+  // Wrap up? I don't think so
+  if (level & TOUT_BANNER)
+    fprintf(output, "--------------------------------------------------\n");
+}
+
 int
 transiterror_fcn(int flags,
                  const char *file,

--- a/transit/src/transitstd.c
+++ b/transit/src/transitstd.c
@@ -54,7 +54,6 @@ Thank you for using transit!
 #include <transit.h>
 
 /* keeps tracks of number of errors that where allowed to continue. */
-int transit_nowarn=0;
 int verblevel;
 int maxline=1000;
 

--- a/transit/src/transitstd.c
+++ b/transit/src/transitstd.c
@@ -279,30 +279,30 @@ verbfileopen(char *in,     /* Input filename              */
   case 1:
     return fp;
   case 0:
-    transiterror(TERR_SERIOUS, "No file was given to open.\n");
+    tr_output(TOUT_ERROR, "No file was given to open.\n");
     return NULL;
   /* File doesn't exist: */
   case -1:
-    transiterror(TERR_SERIOUS, "%s file '%s' doesn't exist.\n", desc, in);
+    tr_output(TOUT_ERROR, "%s file '%s' doesn't exist.\n", desc, in);
     return NULL;
   /* Filetype not valid: */
   case -2:
-    transiterror(TERR_SERIOUS, "%s file '%s' is not of a valid kind "
+    tr_output(TOUT_ERROR, "%s file '%s' is not of a valid kind "
                                "(it is a dir or device)\n", desc, in);
     return NULL;
   /* File not openable: */
   case -3:
-    transiterror(TERR_SERIOUS, "%s file '%s' is not openable. Probably "
+    tr_output(TOUT_ERROR, "%s file '%s' is not openable. Probably "
                                "because of permissions.\n", desc, in);
     return NULL;
   /* stat returned -1: */
   case -4:
-    transiterror(TERR_SERIOUS,
+    tr_output(TOUT_ERROR,
                  "Error happened for %s file '%s', stat() returned -1, "
                  "but file exists.\n", desc, in);
     return NULL;
   default:
-    transiterror(TERR_SERIOUS,
+    tr_output(TOUT_ERROR,
                  "Something weird in file %s, line %i.\n", __FILE__, __LINE__);
   }
   return NULL;
@@ -347,8 +347,10 @@ transitcheckcalled(const long pi,   /* Progress indicator variable          */
   }
   va_end(ap);
   /* Print out the error: */
-  if(stop)
-    transiterror(TERR_CRITICAL, mess, fcn);
+  if(stop) {
+    tr_output(TOUT_ERROR, mess, fcn);
+    exit(EXIT_FAILURE);
+  }
 }
 
 
@@ -466,9 +468,9 @@ void
 linetoolong(int max,     /* Maxiumum length of an accepted line */
             char *file,  /* File from which we were reading     */
             int line){   /* Line who was being read             */
-  transiterror(TERR_SERIOUS|TERR_ALLOWCONT,
-               "Line %i of file '%s' has more than %i characters, "
-               "that is not allowed.\n", file, max);
+  tr_output(TOUT_ERROR,
+    "Line %i of file '%s' has more than %i characters, "
+    "that is not allowed.\n", file, max);
   exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
Todo:
- [x] Compiles and runs exactly as before
- [x] @rychallener, can you check the logic in `tr_output_vfnc` against the now-removed `vtransiterror_fcn` to make sure things match up?
- [ ] Need to add a statement to the user manual concerning the use of redirection to put everything except errors into a logfile.
- [ ] Need to strongly advise **against** using verblevel 5 in usage.
- [x] Do any of the existing output statements need to have their levels changed?
