### PR TITLE
Fixed glitch when reading atmospheric files containing the

### DIFF
--- a/pu/src/iomisc.c
+++ b/pu/src/iomisc.c
@@ -1080,7 +1080,7 @@ void
 getname(char *line,
         char *name){
   /* Copy characters from line into name:                                   */
-  while (*line != ' ' && *line != '\n' && *line != '\0'){
+  while (*line != ' ' && *line != '\n' && *line != '\0' && *line != '\r'){
     *name++ = *line++;
   }
   /* Append the terminating null-character:                                 */

--- a/transit/src/readatm.c
+++ b/transit/src/readatm.c
@@ -339,6 +339,7 @@ getmnfromfile(FILE *fp,                /* Pointer to atmospheric file       */
                         at->begline++)){
     /* Ignore comments and blank lines:                                     */
     case '\n':
+    case '\r':
       continue;
     case '#':
       getname(line+1, keyword);


### PR DESCRIPTION
carriage-return character.
Added the carriage-return character to the list of characters
to detect in getname().
