### PR TITLE
Osx fix

### DIFF
--- a/pu/Makefile
+++ b/pu/Makefile
@@ -97,6 +97,9 @@ COMP_FLAG = $(WARN_FLAG) $(INCL_FLAG) $(LIBR_FLAG) $(OTHR_FLAG)
 
 # Archive flags
 #
+PLATFORM := $(shell uname)
+# These next options are only needed on linux builds
+ifeq ($(PLATFORM), Linux)
 ARCH_FLAG = -Wl,--whole-archive
 
 # Flags for linking the m library
@@ -106,6 +109,7 @@ LIBM_FLAG = -Wl,--no-whole-archive -lm
 # Flags for naming the library
 #
 NAME_FLAG = -Wl,-soname -Wl,libpu.so.1
+endif
 
 # Library linking must be last in the GCC command
 #

--- a/pu/src/xmalloc.c
+++ b/pu/src/xmalloc.c
@@ -75,7 +75,12 @@ fixup_null_alloc (n)
   if (n == 0)
     p = malloc ((size_t) 1);
   if (p == 0)
-    error (xmalloc_exit_failure, 0, _("Memory exhausted"));
+    #if __linux__
+      // on linux if there is no more memory the program
+      // will fail out nicely, other platforms will fail with
+      // standard platform error messages
+      error (xmalloc_exit_failure, 0, _("Memory exhausted"));
+    #endif
   return p;
 }
 


### PR DESCRIPTION
This patch allows transit to build and run on os x (at least on 10.13). It has been tested with gcc-8 and llvm-9.1 (clang)