### PR TITLE
Memfix

### DIFF
--- a/pylineread/src/db_voplez.py
+++ b/pylineread/src/db_voplez.py
@@ -82,7 +82,7 @@ class voplez(dbdriver):
     Notes:
     ------
     The partition function is valid for the range of temperatures from
-    1000K to 7000K.
+    1000K to 7000K. It is extrapolated down to 0K.
 
     Sample Return:
     Temp = np.linspace(1000., 7000., 13):

--- a/transit/src/opacity.c
+++ b/transit/src/opacity.c
@@ -564,7 +564,8 @@ attachopacity(struct transit *tr){ /* transit struct                        */
   op->Nlayer = oh->Nlayer;
   op->Nmol = oh->Nmol;
 
-  int main_shm_size  /* Size of the main shared memory, starting with: grid */
+  /* Size of the main shared memory, starting with: grid */
+  long long main_shm_size  
     = sizeof(PREC_RES) * op->Nmol * op->Ntemp * op->Nlayer * op->Nwave
     + sizeof(int) * op->Nmol          /* op->molID  */
     + sizeof(PREC_RES) * op->Ntemp    /* op->temp   */

--- a/transit/src/readlineinfo.c
+++ b/transit/src/readlineinfo.c
@@ -424,10 +424,10 @@ int readdatarng(struct transit *tr,   /* transit structure                  */
       *isotran,          /* Number of transitions per isotope in TLI        */
       start,             /* Position of first LT for isotope in TLI         */
       i,                 /* for-loop index                                  */
-      offset=0,          /* Isotope offset (in number of transitions)       */
-      wl_loc, iso_loc,   /* Offsets for isoID, Elow, and gf data            */
-      el_loc, gf_loc,    /* (in memory)                                     */
-      rn;                /* Return IDs                                      */
+      offset=0;          /* Isotope offset (in number of transitions)       */
+  long long wl_loc, iso_loc,   /* Offsets for isoID, Elow, and gf data      */
+            el_loc, gf_loc;    /* (in memory)                               */
+  int rn;                /* Return IDs                                      */
   /* Indices of first and last transitions to be stored                     */
   long ifirst, ilast;
 


### PR DESCRIPTION
Fixes issues with integer overflows when using very large TLI and opacity files.